### PR TITLE
windows下文档问答上传文件报错问题修复

### DIFF
--- a/qwen_agent/tools/doc_parser.py
+++ b/qwen_agent/tools/doc_parser.py
@@ -77,7 +77,7 @@ def process_file(url: str, db: Storage = None):
     if url.split('.')[-1].lower() in ['pdf', 'docx', 'pptx']:
         date1 = datetime.datetime.now()
 
-        if url.startswith('https://') or url.startswith('http://'):
+        if url.startswith('https://') or url.startswith('http://') or re.match(r'^[A-Za-z]:\\', win_path) or re.match(r'^[A-Za-z]:/', win_path):
             pdf_path = url
         else:
             parsed_url = urlparse(url)

--- a/run_server.py
+++ b/run_server.py
@@ -5,9 +5,6 @@ import signal
 import subprocess
 import sys
 from pathlib import Path
-
-from qwen_agent.log import logger
-from qwen_agent.utils.utils import get_local_ip
 from qwen_server.schema import GlobalConfig
 
 
@@ -72,13 +69,16 @@ def main():
         server_config = GlobalConfig(**server_config)
     server_config = update_config(server_config, args, server_config_path)
 
-    logger.info(server_config)
+
 
     os.makedirs(server_config.path.work_space_root, exist_ok=True)
     os.makedirs(server_config.path.database_root, exist_ok=True)
     os.makedirs(server_config.path.download_root, exist_ok=True)
 
     os.makedirs(server_config.path.code_interpreter_ws, exist_ok=True)
+    from qwen_agent.log import logger
+    from qwen_agent.utils.utils import get_local_ip
+    logger.info(server_config)
     code_interpreter_work_dir = str(
         Path(__file__).resolve().parent /
         server_config.path.code_interpreter_ws)


### PR DESCRIPTION
window下启动work_station，上传文件后，win_path类型被解析成无盘符的路径，导致ValueError报错，File path xxxx is not a valid file or url，修改为判断是否win_path，是的话直接返回