### PR TITLE
fix a bug in signal registration

### DIFF
--- a/qwen_agent/tools/code_interpreter.py
+++ b/qwen_agent/tools/code_interpreter.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import time
 import uuid
+import threading
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
@@ -48,9 +49,12 @@ def _kill_kernels_and_subprocesses(_sig_num=None, _frame=None):
 
 
 # Make sure all subprocesses are terminated even if killed abnormally:
-atexit.register(_kill_kernels_and_subprocesses)
-append_signal_handler(signal.SIGTERM, _kill_kernels_and_subprocesses)
-append_signal_handler(signal.SIGINT, _kill_kernels_and_subprocesses)
+# If not running in the main thread, (for example run in streamlit)
+# register a signal would cause a RuntimeError
+if threading.current_thread() is threading.main_thread():
+    atexit.register(_kill_kernels_and_subprocesses)
+    append_signal_handler(signal.SIGTERM, _kill_kernels_and_subprocesses)
+    append_signal_handler(signal.SIGINT, _kill_kernels_and_subprocesses)
 
 
 @register_tool('code_interpreter')


### PR DESCRIPTION
# Bug in signal registration
- I encountered the bug when I tried to use qwen-agent in [streamlit](https://github.com/streamlit/streamlit)
``` python
File "~/llm/venv/lib/python3.12/sitepackages/streamlit/runtime/scriptrunner/script_runner.py", line 579, in
code_to_exec
exec(code, module.__dict__)
File "~/llm/demo/secDemo.py", line 6, in <module>
from qwen_agent.llm import get_chat_model
File "~/llm/venv/lib/python3.12/sitepackages/qwen_agent/__init__.py", line 2, in <module>
from .agent import Agent
File "~/venv/lib/python3.12/sitepackages/qwen_agent/agent.py", line 11, in <module>
from qwen_agent.tools import TOOL_REGISTRY, BaseTool
File "~/venv/lib/python3.12/sitepackages/qwen_agent/tools/__init__.py", line 3, in <module>
from .code_interpreter import CodeInterpreter
File "~/venv/lib/python3.12/sitepackages/qwen_agent/tools/code_interpreter.py", line 52, in <module>
append_signal_handler(signal.SIGTERM, _kill_kernels_and_subprocesses)
File "~/venv/lib/python3.12/sitepackages/qwen_agent/utils/utils.py", line 48, in append_signal_handler
signal.signal(sig, new_handler)
File "/usr/lib/python3.12/signal.py", line 58, in signal
handler = _signal.signal(_enum_to_int(signalnum),
_enum_to_int(handler))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: signal only works in main thread of the main interpreter
