### PR TITLE
move fncall_prompt_type to cfg

### DIFF
--- a/examples/function_calling.py
+++ b/examples/function_calling.py
@@ -25,8 +25,9 @@ def test(fncall_prompt_type: str = 'qwen'):
         'model': 'qwen2.5-72b-instruct',
         'model_server': 'dashscope',
         'api_key': os.getenv('DASHSCOPE_API_KEY'),
+        'fncall_prompt_type': fncall_prompt_type,
         'generate_cfg': {
-            'fncall_prompt_type': fncall_prompt_type
+            # 'fncall_prompt_type': fncall_prompt_type
         },
 
         # Use the OpenAI-compatible model service provided by DashScope:

--- a/qwen_agent/llm/function_calling.py
+++ b/qwen_agent/llm/function_calling.py
@@ -10,7 +10,7 @@ class BaseFnCallModel(BaseChatModel, ABC):
 
     def __init__(self, cfg: Optional[Dict] = None):
         super().__init__(cfg)
-        fncall_prompt_type = self.generate_cfg.get('fncall_prompt_type', 'qwen')
+        fncall_prompt_type = cfg.get('fncall_prompt_type', 'qwen')
         if fncall_prompt_type == 'qwen':
             from qwen_agent.llm.fncall_prompts.qwen_fncall_prompt import FN_STOP_WORDS, QwenFnCallPrompt
             self.fncall_prompt = QwenFnCallPrompt()


### PR DESCRIPTION
If we use default vllm to deploy model (Openai also?), the acceptable generate params is limited (only top_p, temeprature, ..). So if we put fncall_prompt_type in generate_cfg, it will make the api call fail. How about move it to llm_cfg?