### PR TITLE
repair image_gen can’t show image

### DIFF
--- a/qwen_agent/gui/utils.py
+++ b/qwen_agent/gui/utils.py
@@ -17,6 +17,7 @@ TOOL_OUTPUT = '''
 
 {tool_output}
 </details>
+
 '''
 
 


### PR DESCRIPTION
当调用image_gen 生成图片时展示失败：如下
![Image](https://github.com/user-attachments/assets/f83b08cb-b1cf-4e18-83c8-e0c9aadd0373)
原因是qwen_agent.gui.utils.convert_fncall_to_text这里将多行msg合并成一行，
导致markdown解析失败，只要在TOOL_OUTPUT后加个换行就可正常显示
![Image](https://github.com/user-attachments/assets/55de21aa-05ed-4b4c-94ec-355923b83016)