### PR TITLE
修复bug-Message里面的reasoning_content字段

### DIFF
--- a/qwen_agent/llm/oai.py
+++ b/qwen_agent/llm/oai.py
@@ -135,7 +135,7 @@ class TextChatAtOAI(BaseFnCallModel):
 
     @staticmethod
     def convert_messages_to_dicts(messages: List[Message]) -> List[dict]:
-        messages = [msg.model_dump() for msg in messages]
+        messages = [msg.model_dump(exclude={'reasoning_content'}) for msg in messages]
         # RM default system
         if messages[0]['role'] == 'system' and messages[0]['content'] == DEFAULT_SYSTEM_MESSAGE:
             messages = messages[1:]


### PR DESCRIPTION
使用vllm启动的qwq-32b服务端，由于Message里面增加了reasoning_content这个字段，在请求的时候，直接报错http 400错误，需要在入参的时候，删除这个字段