### PR TITLE
Update memo_assistant.py

### DIFF
--- a/qwen_agent/agents/memo_assistant.py
+++ b/qwen_agent/agents/memo_assistant.py
@@ -49,7 +49,7 @@ class MemoAssistant(Assistant):
         new_message = self._prepend_storage_info_to_sys(messages)
         new_message = self._truncate_dialogue_history(new_message)
 
-        for rsp in super()._run(new_message, lang, max_ref_token, **kwargs):
+        for rsp in super()._run(new_message, lang, '', **kwargs):
             yield rsp
 
     def _prepend_storage_info_to_sys(self, messages: List[Message]) -> List[Message]:


### PR DESCRIPTION
the super call args:
_run(self,
             messages: List[Message],
             lang: Literal['en', 'zh'] = 'en',
             knowledge: str = '',
             **kwargs) -> Iterator[List[Message]]

there is no "max_ref_token",  it would throw an error:

2025-05-06 21:27:05,564 - utils.py - 71 - ERROR - Traceback (most recent call last):
  File "/Users/vincent/PycharmProjects/cre-gocloud-test/qwen_agent/agents/assistant.py", line 53, in format_knowledge_to_source_and_content
    assert isinstance(docs, list)
           ^^^^^^^^^^^^^^^^^^^^^^
AssertionError
