### PR TITLE
Don’t Fail on Missing Tool Schema Fields—Log Warning

### DIFF
--- a/qwen_agent/tools/mcp_manager.py
+++ b/qwen_agent/tools/mcp_manager.py
@@ -152,7 +152,8 @@ class MCPManager:
                 required_fields = {'type', 'properties', 'required'}
                 missing_fields = required_fields - parameters.keys()
                 if missing_fields:
-                    raise ValueError(f'Missing required fields in schema: {missing_fields}')
+                    logger.warning(f'Tool "{tool.name}" has missing required fields in schema: {missing_fields}, skipping this tool')
+                    continue
 
                 # Keep only the necessary fields
                 cleaned_parameters = {


### PR DESCRIPTION
This PR updates mcp_manager.py so that when a tool’s input schema is missing required fields (type, properties, or required), the code now logs a warning and skips the tool, instead of raising an error and interrupting execution.

Details:

Previously, if a tool’s input schema was missing required fields, the code would raise an error, potentially breaking agent workflows.
Now, the code checks for missing fields and, if any are absent, logs a warning (with the tool name and the missing fields) and continues processing the remaining tools.
This makes the agent more robust to third-party or custom tools with incomplete schemas, improving usability and fault tolerance.
Motivation:
This change ensures that a single misconfigured tool does not prevent the agent from starting or using other tools, making the system more resilient and user-friendly.