### PR TITLE
fix preprocess_fncall_messages

### DIFF
--- a/qwen_agent/llm/fncall_prompts/nous_fncall_prompt.py
+++ b/qwen_agent/llm/fncall_prompts/nous_fncall_prompt.py
@@ -92,6 +92,7 @@ class NousFnCallPrompt(BaseFnCallPrompt):
         tool_descs = [{'type': 'function', 'function': f} for f in functions]
         tool_names = [function.get('name_for_model', function.get('name', '')) for function in functions]
         tool_descs = '\n'.join([json.dumps(f, ensure_ascii=False) for f in tool_descs])
+        tool_descs = tool_descs.encode('utf-8').decode('unicode_escape')
         if SPECIAL_CODE_MODE and any([CODE_TOOL_PATTERN in x for x in tool_names]):
             tool_system = FN_CALL_TEMPLATE_WITH_CI.format(tool_descs=tool_descs)
         else:


### PR DESCRIPTION
Fix the preprocess_fncall_maessages function to address the issue of escape character errors in messages.

针对issue中提出的 NousFnCallPrompt 类的 preprocess_fncall_messages 函数会错误地构造 messages 的问题，解决了二次转义带来的错误，防止 preprocess_fncall_messages 对输入 functions 作出的错误修改，将 json 字符串化之后的 tool_descs 进行反向转义解码，使输出 messages 与函数输入保持一致。