### PR TITLE
fix: allow tools that can return empty lists to execute correctly

### DIFF
--- a/qwen_agent/tools/mcp_manager.py
+++ b/qwen_agent/tools/mcp_manager.py
@@ -449,14 +449,10 @@ class MCPClient:
                 return f'Error: {e}'
         else:
             response = await self.session.call_tool(tool_name, tool_args)
-            texts = []
-            for content in response.content:
-                if content.type == 'text':
-                    texts.append(content.text)
-            if texts:
-                return '\n\n'.join(texts)
-            else:
+            if not response or response.isError:
                 return 'execute error'
+            texts = [c.text for c in response.content if c.type == 'text']
+            return '\n\n'.join(texts)
 
     async def cleanup(self):
         await self.exit_stack.aclose()


### PR DESCRIPTION
Several MCP tools legitimately return an empty list ([]) during normal operation—for example, when a keyword search yields no matches within a phrase. However, the current implementation in mcp_manager.py incorrectly treats any empty list as an "execution error."

This PR refines the logic to distinguish between true execution errors and valid empty responses. If a tool invocation returns an empty list, it is now correctly serialized and passed downstream to the LLM without being flagged as an error
