### PR TITLE
Rename tool registration from 'code_interpreter' to 'codeInterpreter'

### DIFF
--- a/qwen_agent/tools/code_interpreter.py
+++ b/qwen_agent/tools/code_interpreter.py
@@ -71,7 +71,7 @@ if threading.current_thread() is threading.main_thread():
     append_signal_handler(signal.SIGINT, _kill_kernels_and_subprocesses)
 
 
-@register_tool('code_interpreter')
+@register_tool('codeInterpreter')
 class CodeInterpreter(BaseToolWithFileAccess):
     description = 'Python code sandbox, which can be used to execute Python code.'
     parameters = {


### PR DESCRIPTION
Fix #682 