### PR TITLE
Don't pop max_input_tokens

### DIFF
--- a/qwen_agent/llm/base.py
+++ b/qwen_agent/llm/base.py
@@ -177,7 +177,7 @@ class BaseChatModel(ABC):
             messages = [Message(role=SYSTEM, content=DEFAULT_SYSTEM_MESSAGE)] + messages
 
         # Not precise. It's hard to estimate tokens related with function calling and multimodal items.
-        max_input_tokens = generate_cfg.pop('max_input_tokens', DEFAULT_MAX_INPUT_TOKENS)
+        max_input_tokens = generate_cfg.get('max_input_tokens', DEFAULT_MAX_INPUT_TOKENS)
         if max_input_tokens > 0:
             messages = _truncate_input_messages_roughly(
                 messages=messages,


### PR DESCRIPTION
dashscope still needs it: https://help.aliyun.com/zh/model-studio/use-qwen-by-calling-api#8f3edaf4ac7iu