### PR TITLE
Fix(tools): Prevent VLM tool from returning image in assistant message

### DIFF
--- a/examples/qwen2vl_assistant_tooluse.py
+++ b/examples/qwen2vl_assistant_tooluse.py
@@ -280,7 +280,7 @@ class CropResize(BaseToolWithFileAccess):
         cropped_image.save(output_path)
 
         return [
-            ContentItem(image=output_path),
+            # ContentItem(image=output_path),
             ContentItem(text=f'（ 这张放大的局部区域的图片的URL是 {output_path} ）'),
         ]
 


### PR DESCRIPTION
### What problem does this PR solve?

Currently, when using the `CropResize` tool in `qwen2vl_assistant_tooluse.py`, the agent fails with a `ModelServiceError: InvalidParameter`. The error message indicates that an `image` modal cannot be placed in an `assistant` message.

This happens because the `CropResize.call` method returns a `ContentItem(image=output_path)`, which the agent framework then incorrectly tries to send as part of the `assistant`'s turn, violating the model's API rules.

### How does this PR solve the problem?

This PR fixes the issue by commenting out the line that returns the `ContentItem` with an image.

- **Before:** The tool returned `[ContentItem(image=...), ContentItem(text=...)]`.
- **After:** The tool now only returns `[ContentItem(text=...)]`, which correctly provides the path to the generated image within the text message.

This change aligns the tool's behavior with the API's requirements, allowing the interaction to complete successfully while still providing the user with the necessary information about the generated file.
