### PR TITLE
Simplify register_name assignment based on server count

### DIFF
--- a/qwen_agent/tools/mcp_manager.py
+++ b/qwen_agent/tools/mcp_manager.py
@@ -194,7 +194,10 @@ class MCPManager:
                     'properties': parameters['properties'],
                     'required': parameters['required']
                 }
-                register_name = server_name + '-' + tool.name
+                if len(mcp_servers) > 1:
+                    register_name = server_name + '-' + tool.name
+                else:
+                    register_name = tool.name
                 agent_tool = self.create_tool_class(register_name=register_name,
                                                     register_client_id=client_id,
                                                     tool_name=tool.name,


### PR DESCRIPTION
只有 1 个`mcp_server`的时候，不需要添加 `server_name`
```py
                if len(mcp_servers) > 1:
                    register_name = server_name + '-' + tool.name
                else:
                    register_name = tool.name
```