### PR TITLE
fix: resolve SyntaxError in mcp_manager.py due to nested quotes in f-string

### DIFF
--- a/qwen_agent/tools/mcp_manager.py
+++ b/qwen_agent/tools/mcp_manager.py
@@ -139,7 +139,7 @@ class MCPManager:
     def initConfig(self, config: Dict):
         if not self.is_valid_mcp_servers(config):
             raise ValueError('Config of mcpservers is not valid')
-        logger.info(f'Initializing MCP tools from mcp servers: {list(config['mcpServers'].keys())}')
+        logger.info(f"Initializing MCP tools from mcp servers: {list(config['mcpServers'].keys())}")
         # Submit coroutine to the event loop and wait for the result
         future = asyncio.run_coroutine_threadsafe(self.init_config_async(config), self.loop)
         try:


### PR DESCRIPTION
This PR fixes a `SyntaxError` in `qwen_agent/tools/mcp_manager.py`.

The error is caused by nested single quotes inside an f-string, which is invalid in Python versions prior to 3.12. Since many environments (including the one I used, Python 3.10) still rely on these versions, this bug prevents the library from being imported or executed.

**Error Traceback:**

```python
  File "qwen_agent/tools/mcp_manager.py", line 142
    logger.info(f'Initializing MCP tools from mcp servers: {list(config['mcpServers'].keys())}')
                                                                         ^^^^^^^^^^
SyntaxError: f-string: unmatched '['

```

**Changes:**

* Changed the outer quotes of the f-string from single quotes (`'`) to double quotes (`"`) to allow the use of single quotes for the dictionary key access.