### PR TITLE
Fix double-escaping of special characters in NousFnCallPrompt

### DIFF
--- a/qwen_agent/llm/fncall_prompts/nous_fncall_prompt.py
+++ b/qwen_agent/llm/fncall_prompts/nous_fncall_prompt.py
@@ -90,6 +90,9 @@ class NousFnCallPrompt(BaseFnCallPrompt):
         tool_descs = [{'type': 'function', 'function': f} for f in functions]
         tool_names = [function.get('name_for_model', function.get('name', '')) for function in functions]
         tool_descs = '\n'.join([json.dumps(f, ensure_ascii=False) for f in tool_descs])
+        # Decode JSON string escapes to prevent double-escaping during API serialization,
+        # so that the model sees actual whitespace characters instead of escape sequences.
+        tool_descs = tool_descs.replace('\\n', '\n').replace('\\t', '\t').replace('\\r', '\r')
         if SPECIAL_CODE_MODE and any([CODE_TOOL_PATTERN in x for x in tool_names]):
             tool_system = FN_CALL_TEMPLATE_WITH_CI.format(tool_descs=tool_descs)
         else:


### PR DESCRIPTION
## Problem

When function descriptions contain special characters like newlines (`\n`), tabs (`\t`), etc., the `preprocess_fncall_messages` method in `NousFnCallPrompt` double-escapes them.

`json.dumps` correctly escapes `\n` → `\\n` in the JSON string. However, when this text is later serialized again for the API call, the backslash gets escaped again, resulting in `\\\\n` being sent to the model instead of an actual newline.

This is also visible in the official Qwen2.5-VL cookbook: https://github.com/QwenLM/Qwen2.5-VL/blob/main/cookbooks/computer_use.ipynb (search for `\\\\n`).

## Fix

After `json.dumps`, decode common JSON string escapes (`\\n`, `\\t`, `\\r`) back to actual characters. This prevents double-escaping during API serialization, so the model sees actual whitespace characters instead of escape sequences.

## Changes

- `qwen_agent/llm/fncall_prompts/nous_fncall_prompt.py`: Added post-processing to decode JSON string escapes after `json.dumps` (1 line).

Fixes #659