### PR TITLE
Add configurable max_output_length to PythonExecutor

### DIFF
--- a/qwen_agent/tools/python_executor.py
+++ b/qwen_agent/tools/python_executor.py
@@ -125,6 +125,7 @@ class PythonExecutor(BaseTool):
         self.get_answer_from_stdout = get_answer_from_stdout
         self.pool = Pool(multiprocess.cpu_count())
         self.timeout_length = timeout_length
+        self.max_output_length: Optional[int] = self.cfg.get('max_output_length', 256)
 
     def call(self, params: Union[str, dict], **kwargs) -> list:
         try:
@@ -181,6 +182,8 @@ class PythonExecutor(BaseTool):
 
     @staticmethod
     def truncate(s, max_length=256):
+        if not max_length:
+            return s
         half = max_length // 2
         if len(s) > max_length:
             s = s[:half] + '...' + s[-half:]
@@ -232,7 +235,7 @@ class PythonExecutor(BaseTool):
         for code, (res, report) in zip(all_code_snippets, all_exec_results):
             # post processing
             res, report = str(res).strip(), str(report).strip()
-            res, report = self.truncate(res), self.truncate(report)
+            res, report = self.truncate(res, self.max_output_length), self.truncate(report, self.max_output_length)
             batch_results.append((res, report))
         return batch_results
 


### PR DESCRIPTION
## Problem

`PythonExecutor.truncate()` always truncates output to a hardcoded 256 characters with no option to configure or disable it. This makes it impossible to get full results from code execution.

## Fix

Add a `max_output_length` config parameter to `PythonExecutor`:

- Default: `256` (preserves current behavior)
- Set to `0` or `None` to disable truncation

Usage:
```python
# Default (truncates to 256 chars)
executor = PythonExecutor()

# Custom length
executor = PythonExecutor(cfg={'max_output_length': 1024})

# Disable truncation
executor = PythonExecutor(cfg={'max_output_length': 0})
```

## Changes

- `qwen_agent/tools/python_executor.py`: Add `max_output_length` config option, skip truncation when falsy.

Fixes #683