### PR TITLE
Add resource_templates support to MCP resource discovery

### DIFF
--- a/qwen_agent/tools/mcp_manager.py
+++ b/qwen_agent/tools/mcp_manager.py
@@ -381,8 +381,14 @@ class MCPClient:
                 if list_resources.resources:
                     self.resources = True
             except Exception:
-                # logger.info(f"No list resources: {e}")
                 pass
+            if not self.resources:
+                try:
+                    list_resource_templates = await self.session.list_resource_templates()
+                    if list_resource_templates.resourceTemplates:
+                        self.resources = True
+                except Exception:
+                    pass
         except Exception as e:
             logger.warning(f'Failed in connecting to MCP server: {e}')
             raise e
@@ -421,12 +427,24 @@ class MCPClient:
                 return f'Session reconnect (client creation) exception: {e3}'
         if tool_name == 'list_resources':
             try:
-                list_resources = await self.session.list_resources()
-                if list_resources.resources:
-                    resources_str = '\n\n'.join(str(resource) for resource in list_resources.resources)
+                parts = []
+                try:
+                    list_resources = await self.session.list_resources()
+                    if list_resources.resources:
+                        parts.append('\n\n'.join(str(resource) for resource in list_resources.resources))
+                except Exception as e:
+                    logger.info(f'No list resources: {e}')
+                try:
+                    list_resource_templates = await self.session.list_resource_templates()
+                    if list_resource_templates.resourceTemplates:
+                        parts.append('\n\n'.join(
+                            str(template) for template in list_resource_templates.resourceTemplates))
+                except Exception as e:
+                    logger.info(f'No list resource templates: {e}')
+                if parts:
+                    return '\n\n'.join(parts)
                 else:
-                    resources_str = 'No resources found'
-                return resources_str
+                    return 'No resources found'
             except Exception as e:
                 logger.info(f'No list resources: {e}')
                 return f'Error: {e}'


### PR DESCRIPTION
## Problem

The MCP manager has two issues with resource template handling:

1. **Server detection** (`connection_server`): Only `list_resources()` is checked when detecting if a server has resources. Servers that only provide resource_templates are not detected, so their resource tools are never registered. (Fixes #581)

2. **Resource listing** (`execute_function`): The `list_resources` tool only calls `session.list_resources()` and doesn't include resource templates in the output, making the resource list incomplete for the LLM. (Fixes #582)

## Fix

- In `connection_server`: Also check `list_resource_templates()` when `list_resources()` returns empty, so servers with only resource templates are properly detected.
- In `execute_function`: When listing resources, also call `list_resource_templates()` and include templates in the output alongside resources.

## Changes

- `qwen_agent/tools/mcp_manager.py`: Two fixes in `MCPClient` class.

Fixes #582
Fixes #581