### PR TITLE
fix: add soundfile to requirements.txt for deepplanning

### DIFF
--- a/benchmark/deepplanning/requirements.txt
+++ b/benchmark/deepplanning/requirements.txt
@@ -36,4 +36,5 @@ tiktoken>=0.5.0                  # Token counting for OpenAI models
 eval-type-backport               # Type evaluation backport (Travel domain)
 pillow>=9.0.0                    # Image processing (if needed)
 tabulate>=0.9.0                  # Pretty-print tabular data
+soundfile>=0.12.1                # Dependency required by qwen-agent import chain
 


### PR DESCRIPTION
fix: 在 requirements.txt 中添加 soundfile 依赖，修复 travelplanning 工具调用问题 #798

fix: add soundfile to requirements.txt for travelplanning tool calls #798

fixes #798