### PR TITLE
fix: handle FastAPI serialization for Message objects

### DIFF
--- a/qwen_agent/llm/schema.py
+++ b/qwen_agent/llm/schema.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, SerializationInfo, field_validator, model_serializer, model_validator
 
 DEFAULT_SYSTEM_MESSAGE = ''
 
@@ -41,6 +41,20 @@ class BaseModelCompatibleDict(BaseModel):
 
     def __setitem__(self, key, value):
         setattr(self, key, value)
+
+    @model_serializer(mode='wrap')
+    def _exclude_none_serializer(self, handler: Any, info: SerializationInfo) -> Dict[str, Any]:
+        """Ensure None values are excluded during serialization.
+
+        This handles the case where external frameworks (e.g. FastAPI) serialize
+        the model via ``TypeAdapter`` or ``jsonable_encoder``, bypassing the
+        custom ``model_dump`` override.  By filtering at the serializer level
+        the behaviour is consistent regardless of the call path.
+        """
+        result = handler(self)
+        if not info.exclude_none:
+            return {k: v for k, v in result.items() if v is not None}
+        return result
 
     def model_dump(self, **kwargs):
         if 'exclude_none' not in kwargs:

--- a/tests/llm/test_schema.py
+++ b/tests/llm/test_schema.py
@@ -1,0 +1,135 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Message serialization, especially FastAPI compatibility (issue #347)."""
+
+import json
+
+import pytest
+from pydantic import TypeAdapter
+
+from qwen_agent.llm.schema import ContentItem, FunctionCall, Message
+
+
+class TestMessageModelDump:
+    """model_dump() should exclude None fields by default."""
+
+    def test_basic_message_excludes_none(self):
+        msg = Message(role='user', content='hello')
+        dump = msg.model_dump()
+        assert dump == {'role': 'user', 'content': 'hello'}
+        assert 'name' not in dump
+        assert 'function_call' not in dump
+        assert 'extra' not in dump
+
+    def test_message_with_function_call(self):
+        fc = FunctionCall(name='search', arguments='{"q": "test"}')
+        msg = Message(role='assistant', content='', function_call=fc)
+        dump = msg.model_dump()
+        assert dump == {
+            'role': 'assistant',
+            'content': '',
+            'function_call': {
+                'name': 'search',
+                'arguments': '{"q": "test"}',
+            },
+        }
+        assert 'name' not in dump
+        assert 'extra' not in dump
+
+    def test_message_with_content_items(self):
+        msg = Message(role='user', content=[ContentItem(text='hello')])
+        dump = msg.model_dump()
+        assert dump['content'] == [{'text': 'hello'}]
+
+    def test_model_dump_json_excludes_none(self):
+        msg = Message(role='user', content='hello')
+        dump_json = msg.model_dump_json()
+        assert 'null' not in dump_json
+        parsed = json.loads(dump_json)
+        assert parsed == {'role': 'user', 'content': 'hello'}
+
+
+class TestContentItemModelDump:
+    """ContentItem.model_dump() should return exactly one field."""
+
+    def test_text_item(self):
+        ci = ContentItem(text='hello')
+        assert ci.model_dump() == {'text': 'hello'}
+
+    def test_image_item(self):
+        ci = ContentItem(image='http://example.com/img.png')
+        assert ci.model_dump() == {'image': 'http://example.com/img.png'}
+
+    def test_get_type_and_value(self):
+        ci = ContentItem(text='hello')
+        t, v = ci.get_type_and_value()
+        assert t == 'text'
+        assert v == 'hello'
+
+
+class TestFastAPICompatibility:
+    """Pydantic TypeAdapter (used by FastAPI) should also exclude None fields.
+
+    This is the core fix for issue #347: FastAPI uses TypeAdapter internally
+    for response serialization, which bypasses custom model_dump() overrides.
+    """
+
+    def test_type_adapter_dump_python_excludes_none(self):
+        msg = Message(role='user', content='hello')
+        ta = TypeAdapter(Message)
+        dump = ta.dump_python(msg)
+        assert 'name' not in dump
+        assert 'function_call' not in dump
+        assert 'extra' not in dump
+
+    def test_type_adapter_dump_json_excludes_none(self):
+        msg = Message(role='user', content='hello')
+        ta = TypeAdapter(Message)
+        dump = ta.dump_json(msg)
+        assert b'null' not in dump
+
+    def test_type_adapter_nested_excludes_none(self):
+        msg = Message(
+            role='assistant',
+            content=[ContentItem(text='hi')],
+            function_call=FunctionCall(name='test', arguments='{}'),
+        )
+        ta = TypeAdapter(Message)
+        dump = ta.dump_python(msg)
+        assert 'name' not in dump
+        assert 'extra' not in dump
+        assert dump['content'] == [{'text': 'hi'}]
+        assert dump['function_call'] == {'name': 'test', 'arguments': '{}'}
+
+
+class TestDictLikeAccess:
+    """BaseModelCompatibleDict dict-like interface should still work."""
+
+    def test_getitem(self):
+        msg = Message(role='user', content='hello')
+        assert msg['role'] == 'user'
+        assert msg['content'] == 'hello'
+
+    def test_setitem(self):
+        msg = Message(role='user', content='hello')
+        msg['name'] = 'tester'
+        dump = msg.model_dump()
+        assert dump['name'] == 'tester'
+
+    def test_get_with_default(self):
+        msg = Message(role='user', content='hello')
+        assert msg.get('name') is None
+        assert msg.get('name', 'default') == 'default'
+        assert msg.get('role') == 'user'


### PR DESCRIPTION
## Summary

- Fixes #347: `BaseModelCompatibleDict.model_dump()` override was being bypassed by FastAPI's serialization pipeline
- Added `@model_serializer(mode='wrap')` to `BaseModelCompatibleDict` that filters out `None` values at the Pydantic serialization level
- This ensures consistent `exclude_none=True` behavior whether serialized via direct `model_dump()`, Pydantic's `TypeAdapter`, or FastAPI's `jsonable_encoder`

## Problem

The overridden `model_dump` method only sets `exclude_none=True` when the caller doesn't pass the parameter. However:

1. **FastAPI's `jsonable_encoder`** calls `model_dump(exclude_none=False)` explicitly, overriding the intended default
2. **Pydantic's `TypeAdapter`** (used by FastAPI for `response_model` validation) bypasses `model_dump()` entirely

This causes `None`-valued fields (`name`, `function_call`, `extra`, etc.) to appear as `null` in API responses.

## Solution

Add a `@model_serializer(mode='wrap')` that operates at the Pydantic core serialization level, ensuring `None` values are filtered regardless of the call path. The existing `model_dump`/`model_dump_json` overrides are preserved for backward compatibility.

## Test plan

- [x] `Message.model_dump()` excludes `None` fields
- [x] `Message.model_dump_json()` excludes `None` fields
- [x] `ContentItem.get_type_and_value()` still works (depends on single-item dict)
- [x] `TypeAdapter(Message).dump_python()` excludes `None` fields
- [x] `TypeAdapter(Message).dump_json()` contains no `null` values
- [x] FastAPI endpoints return clean JSON without `null` fields
- [x] Dict-like access (`__getitem__`, `__setitem__`, `get`) still works
- [x] Added unit tests in `tests/llm/test_schema.py`