### PR TITLE
fix(oai): truncate stop words to OpenAI-compatible limit

### DIFF
--- a/qwen_agent/llm/oai.py
+++ b/qwen_agent/llm/oai.py
@@ -36,6 +36,8 @@ from qwen_agent.log import logger
 @register_llm('oai')
 class TextChatAtOAI(BaseFnCallModel):
 
+    MAX_OAI_STOP_WORDS = 4
+
     def __init__(self, cfg: Optional[Dict] = None):
         super().__init__(cfg)
         self.model = self.model or 'gpt-4o-mini'
@@ -95,6 +97,18 @@ class TextChatAtOAI(BaseFnCallModel):
             self._complete_create = _complete_create
             self._chat_complete_create = _chat_complete_create
 
+    @classmethod
+    def _normalize_generate_cfg_for_oai(cls, generate_cfg: dict) -> dict:
+        normalized_cfg = copy.deepcopy(generate_cfg)
+        stop = normalized_cfg.get('stop')
+        if isinstance(stop, list) and len(stop) > cls.MAX_OAI_STOP_WORDS:
+            logger.warning(
+                f'OpenAI-compatible APIs support at most {cls.MAX_OAI_STOP_WORDS} stop words. '
+                f'Truncating from {len(stop)} to {cls.MAX_OAI_STOP_WORDS}.'
+            )
+            normalized_cfg['stop'] = stop[:cls.MAX_OAI_STOP_WORDS]
+        return normalized_cfg
+
     def _chat_stream(
         self,
         messages: List[Message],
@@ -102,6 +116,7 @@ class TextChatAtOAI(BaseFnCallModel):
         generate_cfg: dict,
     ) -> Iterator[List[Message]]:
         messages = self.convert_messages_to_dicts(messages)
+        generate_cfg = self._normalize_generate_cfg_for_oai(generate_cfg)
         logger.debug(f'LLM Input generate_cfg: \n{generate_cfg}')
         try:
             response = self._chat_complete_create(model=self.model, messages=messages, stream=True, **generate_cfg)
@@ -164,6 +179,7 @@ class TextChatAtOAI(BaseFnCallModel):
         generate_cfg: dict,
     ) -> List[Message]:
         messages = self.convert_messages_to_dicts(messages)
+        generate_cfg = self._normalize_generate_cfg_for_oai(generate_cfg)
         try:
             response = self._chat_complete_create(model=self.model, messages=messages, stream=False, **generate_cfg)
             if hasattr(response.choices[0].message, 'reasoning_content'):

--- a/tests/llm/test_oai_stop_cfg.py
+++ b/tests/llm/test_oai_stop_cfg.py
@@ -1,0 +1,33 @@
+import sys
+from types import ModuleType
+
+
+openai_stub = ModuleType('openai')
+openai_stub.__version__ = '1.0.0'
+openai_stub.OpenAIError = Exception
+openai_stub.OpenAI = object
+sys.modules.setdefault('openai', openai_stub)
+
+from qwen_agent.llm.oai import TextChatAtOAI
+
+
+def test_normalize_generate_cfg_for_oai_truncates_stop_list():
+    original = {
+        'temperature': 0.1,
+        'stop': ['✿RESULT✿', '✿RETURN✿', 'Observation:', 'Observation:\n', '"] , "instruction":'],
+    }
+
+    normalized = TextChatAtOAI._normalize_generate_cfg_for_oai(original)
+
+    assert normalized['stop'] == ['✿RESULT✿', '✿RETURN✿', 'Observation:', 'Observation:\n']
+    assert normalized['temperature'] == 0.1
+    # Keep input unchanged.
+    assert len(original['stop']) == 5
+
+
+def test_normalize_generate_cfg_for_oai_keeps_non_list_stop():
+    original = {'stop': 'Observation:'}
+
+    normalized = TextChatAtOAI._normalize_generate_cfg_for_oai(original)
+
+    assert normalized == original


### PR DESCRIPTION
## Summary
- add a small normalization step in `TextChatAtOAI` to cap `stop` sequences to 4 when calling OpenAI-compatible APIs
- log a warning when truncation happens so behavior is visible in runtime logs
- add unit tests for stop-list truncation + non-list stop passthrough

## Why
OpenAI-compatible endpoints can reject requests when `stop` contains more than 4 entries (issue #370).

## Validation
- `python3 -m py_compile qwen_agent/llm/oai.py tests/llm/test_oai_stop_cfg.py`

Closes #370
