### PR TITLE
Replace assert statements with explicit validation in core modules

### DIFF
--- a/qwen_agent/agent.py
+++ b/qwen_agent/agent.py
@@ -116,8 +116,11 @@ class Agent(ABC):
                 if isinstance(new_messages[0][CONTENT], str):
                     new_messages[0][CONTENT] = self.system_message + '\n\n' + new_messages[0][CONTENT]
                 else:
-                    assert isinstance(new_messages[0][CONTENT], list)
-                    assert new_messages[0][CONTENT][0].text
+                    if not isinstance(new_messages[0][CONTENT], list):
+                        raise TypeError(
+                            f'Expected message content to be a list, got {type(new_messages[0][CONTENT])}')
+                    if not new_messages[0][CONTENT][0].text:
+                        raise ValueError('The first content item of the system message must contain text.')
                     new_messages[0][CONTENT] = [ContentItem(text=self.system_message + '\n\n')
                                                ] + new_messages[0][CONTENT]  # noqa
 

--- a/qwen_agent/agents/group_chat.py
+++ b/qwen_agent/agents/group_chat.py
@@ -66,7 +66,10 @@ class GroupChat(Agent, MultiAgentHub):
             llm: The LLM for inputting to the host.
         """
         super().__init__(**kwargs)
-        assert agent_selection_method in self._VALID_AGENT_SELECTION_METHODS, f'You must choose agent_selection_method from {", ".join(self._VALID_AGENT_SELECTION_METHODS)}'
+        if agent_selection_method not in self._VALID_AGENT_SELECTION_METHODS:
+            raise ValueError(
+                f'Invalid agent_selection_method: {agent_selection_method}. '
+                f'Must be one of: {", ".join(self._VALID_AGENT_SELECTION_METHODS)}')
         self.agent_selection_method = agent_selection_method
 
         if isinstance(agents, dict):
@@ -75,7 +78,8 @@ class GroupChat(Agent, MultiAgentHub):
             self._agents = agents
 
         if self.agent_selection_method == 'auto':
-            assert llm is not None, 'Need to provide LLM to the host in auto mode'
+            if llm is None:
+                raise ValueError('An LLM must be provided to the host when using auto agent selection mode.')
             self.host = GroupChatAutoRouter(function_list=function_list, llm=llm, agents=self.agents, name='host')
 
     def _run(self,
@@ -89,7 +93,8 @@ class GroupChat(Agent, MultiAgentHub):
         messages = copy.deepcopy(messages)
         for message in messages:
             if message.role == 'assistant':
-                assert message.name, 'In group chat, each agent must be given a name'
+                if not message.name:
+                    raise ValueError('In group chat, each assistant message must have a name.')
             # Name will be used for router
             # Todo: Dealing with situations where there are no real players
             if not message.name:
@@ -140,7 +145,10 @@ class GroupChat(Agent, MultiAgentHub):
                 # The topic ends
                 break
             if mentioned_agents_name:
-                assert rsp[-1].name == mentioned_agents_name[0]
+                if rsp[-1].name != mentioned_agents_name[0]:
+                    raise RuntimeError(
+                        f'Expected response from agent "{mentioned_agents_name[0]}", '
+                        f'but got response from "{rsp[-1].name}".')
                 mentioned_agents_name.pop(0)
 
             response += rsp
@@ -180,7 +188,9 @@ class GroupChat(Agent, MultiAgentHub):
             if isinstance(last[-1]['content'], str):
                 auto_selected_agent = last[-1]['content']
             else:
-                assert isinstance(last[-1]['content'], list)
+                if not isinstance(last[-1]['content'], list):
+                    raise TypeError(
+                        f'Expected content to be a list, got {type(last[-1]["content"])}')
                 if 'text' in last[-1]['content'][0]:
                     auto_selected_agent = last[-1]['content'][0]['text']
             if auto_selected_agent in agents_map.keys():
@@ -231,7 +241,9 @@ class GroupChat(Agent, MultiAgentHub):
                 new_msg = None
                 if msg.function_call:
                     # Append the function call msg
-                    assert messages[i + 1].role == 'function'
+                    if i + 1 >= len(messages) or messages[i + 1].role != 'function':
+                        raise ValueError(
+                            'Expected a function message following a function_call, but it is missing.')
                     new_messages.append(copy.deepcopy(messages[i + 1]))
                     i += 1
             else:
@@ -248,8 +260,12 @@ class GroupChat(Agent, MultiAgentHub):
 
                 if msg.function_call:
                     # Skip the function call msg
-                    assert messages[i + 1].role == 'function'
-                    assert messages[i + 2].role == 'assistant' and messages[i + 2].name == msg.name
+                    if i + 1 >= len(messages) or messages[i + 1].role != 'function':
+                        raise ValueError(
+                            'Expected a function message following a function_call, but it is missing.')
+                    if i + 2 >= len(messages) or messages[i + 2].role != 'assistant' or messages[i + 2].name != msg.name:
+                        raise ValueError(
+                            f'Expected an assistant message from "{msg.name}" after the function result, but it is missing.')
                     i += 1
 
             i += 1

--- a/qwen_agent/llm/base.py
+++ b/qwen_agent/llm/base.py
@@ -110,9 +110,12 @@ class BaseChatModel(ABC):
 
     def quick_chat(self, prompt: str) -> str:
         *_, responses = self.chat(messages=[Message(role=USER, content=prompt)])
-        assert len(responses) == 1
-        assert not responses[0].function_call
-        assert isinstance(responses[0].content, str)
+        if len(responses) != 1:
+            raise ValueError(f'Expected exactly 1 response from quick_chat, got {len(responses)}')
+        if responses[0].function_call:
+            raise ValueError('quick_chat does not support function calls in the response.')
+        if not isinstance(responses[0].content, str):
+            raise TypeError(f'Expected response content to be a string, got {type(responses[0].content)}')
         return responses[0].content
 
     def chat(
@@ -219,7 +222,8 @@ class BaseChatModel(ABC):
 
         if self.use_raw_api:
             logger.debug('`use_raw_api` takes effect.')
-            assert stream and (not delta_stream), '`use_raw_api` only support full stream!!!'
+            if not stream or delta_stream:
+                raise ValueError('`use_raw_api` only supports full stream mode (stream=True, delta_stream=False).')
             return self.raw_chat(messages=messages, functions=functions, stream=stream, generate_cfg=generate_cfg)
 
         if not fncall_mode:
@@ -240,7 +244,8 @@ class BaseChatModel(ABC):
             else:
                 # TODO: Optimize code structure
                 if messages[-1].role == ASSISTANT:
-                    assert not delta_stream, 'Continuation mode does not currently support `delta_stream`'
+                    if delta_stream:
+                        raise ValueError('Continuation mode does not currently support `delta_stream`.')
                     return self._continue_assistant_response(messages, generate_cfg=generate_cfg, stream=stream)
                 else:
                     return self._chat(
@@ -259,7 +264,8 @@ class BaseChatModel(ABC):
             output = retry_model_service(_call_model_service, max_retries=self.max_retries)
 
         if isinstance(output, list):
-            assert not stream
+            if stream:
+                raise RuntimeError('Unexpected list output in stream mode. Expected an iterator.')
             logger.debug(f'LLM Output: \n{pformat([_.model_dump() for _ in output], indent=2)}')
             output = self._postprocess_messages(output, fncall_mode=fncall_mode, generate_cfg=generate_cfg)
             if not self.support_multimodal_output:
@@ -268,12 +274,14 @@ class BaseChatModel(ABC):
                 self.cache.set(cache_key, json_dumps_compact(output))
             return self._convert_messages_to_target_type(output, _return_message_type)
         else:
-            assert stream
+            if not stream:
+                raise RuntimeError('Unexpected iterator output in non-stream mode. Expected a list.')
             if delta_stream:
                 # Hack: To avoid potential errors during the postprocessing of stop words when delta_stream=True.
                 # Man, we should never have implemented the support for `delta_stream=True` in the first place!
                 generate_cfg = copy.deepcopy(generate_cfg)  # copy to avoid conflicts with `_call_model_service`
-                assert 'skip_stopword_postproc' not in generate_cfg
+                if 'skip_stopword_postproc' in generate_cfg:
+                    raise ValueError('`skip_stopword_postproc` should not be set in generate_cfg when using delta_stream.')
                 generate_cfg['skip_stopword_postproc'] = True
             output = self._postprocess_messages_iterator(output, fncall_mode=fncall_mode, generate_cfg=generate_cfg)
 
@@ -537,9 +545,12 @@ def _format_as_text_messages(messages: List[Message]) -> List[Message]:
     for msg in messages:
         if isinstance(msg.content, list):
             for item in msg.content:
-                assert item.type == 'text'
-        else:
-            assert isinstance(msg.content, str)
+                if item.type != 'text':
+                    raise TypeError(
+                        f'Expected all content items to be text, got {item.type}. '
+                        'Non-text content is not supported for text-only models.')
+        elif not isinstance(msg.content, str):
+            raise TypeError(f'Expected message content to be a string or list, got {type(msg.content)}')
     messages = [format_as_text_message(msg, add_upload_info=False) for msg in messages]
     return messages
 

--- a/qwen_agent/llm/schema.py
+++ b/qwen_agent/llm/schema.py
@@ -115,7 +115,8 @@ class ContentItem(BaseModelCompatibleDict):
 
     def get_type_and_value(self) -> Tuple[Literal['text', 'image', 'file', 'audio', 'video'], str]:
         (t, v), = self.model_dump().items()
-        assert t in ('text', 'image', 'file', 'audio', 'video')
+        if t not in ('text', 'image', 'file', 'audio', 'video'):
+            raise ValueError(f"Unexpected content type '{t}'. Must be one of: text, image, file, audio, video.")
         return t, v
 
     @property

--- a/qwen_agent/multi_agent_hub.py
+++ b/qwen_agent/multi_agent_hub.py
@@ -25,12 +25,17 @@ class MultiAgentHub(ABC):
     def agents(self) -> List[Agent]:
         try:
             agent_list = self._agents
-            assert isinstance(agent_list, list)
-            assert all(isinstance(a, Agent) for a in agent_list)
-            assert len(agent_list) > 0
-            assert all(a.name for a in agent_list), 'All agents must have a name.'
-            assert len(set(a.name for a in agent_list)) == len(agent_list), 'Agents must have unique names.'
-        except (AttributeError, AssertionError) as e:
+            if not isinstance(agent_list, list):
+                raise TypeError(f"'_agents' must be a list, got {type(agent_list)}")
+            if not all(isinstance(a, Agent) for a in agent_list):
+                raise TypeError("All items in '_agents' must be instances of Agent.")
+            if len(agent_list) == 0:
+                raise ValueError("'_agents' must be a non-empty list containing at least one agent.")
+            if not all(a.name for a in agent_list):
+                raise ValueError('All agents must have a name.')
+            if len(set(a.name for a in agent_list)) != len(agent_list):
+                raise ValueError('Agents must have unique names.')
+        except (AttributeError, TypeError, ValueError) as e:
             logger.error(
                 f'Class {self.__class__.__name__} inherits from MultiAgentHub. '
                 'However, the following constraints are violated: '


### PR DESCRIPTION
Assert statements can be silently disabled when Python runs with the -O (optimize) flag, which means runtime validation is skipped entirely. This replaces assert-based validation with explicit if-checks that raise ValueError, TypeError, or RuntimeError with descriptive error messages.

Files changed:
- agent.py: message content type validation
- llm/base.py: quick_chat response, stream mode, and output validation
- llm/schema.py: ContentItem type validation
- agents/group_chat.py: agent selection, naming, and message structure
- multi_agent_hub.py: agent list type, emptiness, and uniqueness checks