### PR TITLE
fix: Add thread-safe singleton pattern for MCPManager

### DIFF
--- a/qwen_agent/tools/mcp_manager.py
+++ b/qwen_agent/tools/mcp_manager.py
@@ -30,10 +30,12 @@ from qwen_agent.tools.base import BaseTool
 
 class MCPManager:
     _instance = None  # Private class variable to store the unique instance
+    _lock = threading.Lock()  # Lock for thread-safe singleton pattern
 
     def __new__(cls, *args, **kwargs):
-        if cls._instance is None:
-            cls._instance = super(MCPManager, cls).__new__(cls, *args, **kwargs)
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super(MCPManager, cls).__new__(cls, *args, **kwargs)
         return cls._instance
 
     def __init__(self):


### PR DESCRIPTION
## Description

The MCPManager class in `qwen_agent/tools/mcp_manager.py` uses a singleton pattern that is not thread-safe. In a multi-threaded environment (e.g., Gradio WebUI or ASGI server), two threads can both evaluate `cls._instance is None` as True simultaneously, resulting in duplicate MCP server connections and inconsistent state.

## Fix

This PR adds a `threading.Lock` to ensure only one instance is created even when multiple threads access `__new__` concurrently.

```python
class MCPManager:
    _instance = None
    _lock = threading.Lock()  # Lock for thread-safe singleton pattern

    def __new__(cls, *args, **kwargs):
        with cls._lock:
            if cls._instance is None:
                cls._instance = super(MCPManager, cls).__new__(cls, *args, **kwargs)
        return cls._instance
```

## Related Issue

Fixes #812