### PR TITLE
fix: thread-safe singleton pattern in MCPManager

### DIFF
--- a/qwen_agent/tools/mcp_manager.py
+++ b/qwen_agent/tools/mcp_manager.py
@@ -30,10 +30,12 @@ from qwen_agent.tools.base import BaseTool
 
 class MCPManager:
     _instance = None  # Private class variable to store the unique instance
+    _lock = threading.Lock()  # Lock for thread-safe singleton pattern
 
     def __new__(cls, *args, **kwargs):
-        if cls._instance is None:
-            cls._instance = super(MCPManager, cls).__new__(cls, *args, **kwargs)
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super(MCPManager, cls).__new__(cls, *args, **kwargs)
         return cls._instance
 
     def __init__(self):


### PR DESCRIPTION
## Description

Fixes issue #812 - Thread unsafe singleton pattern in MCPManager

The MCPManager class uses a singleton pattern that is not thread-safe. In a multi-threaded environment, two threads can simultaneously evaluate `cls._instance is None` as True, resulting in multiple instances being created.

## Solution

Added `threading.Lock()` to ensure thread-safe singleton creation:

```python
class MCPManager:
    _instance = None
    _lock = threading.Lock()

    def __new__(cls, *args, **kwargs):
        with cls._lock:
            if cls._instance is None:
                cls._instance = super(MCPManager, cls).__new__(cls, *args, **kwargs)
        return cls._instance
```

This prevents race conditions when multiple threads try to initialize MCPManager concurrently (e.g., when serving multiple users via Gradio WebUI or ASGI servers).

## Testing

The fix ensures that only one instance of MCPManager is created even when accessed concurrently from multiple threads.