### PR TITLE
Fix thread-unsafe singleton pattern in MCPManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ llm_cfg = {
 # Step 3: Create an agent. Here we use the `Assistant` agent as an example, which is capable of using tools and reading files.
 system_instruction = '''After receiving the user's request, you should:
 - first draw an image and obtain the image url,
-- then run code `request.get(image_url)` to download the image,
+- then run code `requests.get(image_url)` to download the image,
 - and finally select an image operation from the given document to process the image.
 Please show the image using `plt.show()`.'''
 tools = ['my_image_gen', 'code_interpreter']  # `code_interpreter` is a built-in tool for executing code. For configuration details, please refer to the FAQ.

--- a/qwen_agent/tools/mcp_manager.py
+++ b/qwen_agent/tools/mcp_manager.py
@@ -30,10 +30,14 @@ from qwen_agent.tools.base import BaseTool
 
 class MCPManager:
     _instance = None  # Private class variable to store the unique instance
+    _lock = threading.Lock()  # Lock for thread-safe singleton
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
-            cls._instance = super(MCPManager, cls).__new__(cls, *args, **kwargs)
+            with cls._lock:
+                # Double-checked locking pattern
+                if cls._instance is None:
+                    cls._instance = super(MCPManager, cls).__new__(cls, *args, **kwargs)
         return cls._instance
 
     def __init__(self):


### PR DESCRIPTION
Fixes #812

Add thread-safe singleton using double-checked locking pattern. This prevents race conditions when multiple threads try to create the MCPManager instance simultaneously.