### PR TITLE
fix: correct dotenv dependency to python-dotenv in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'requests',
         'tiktoken',
         'pillow',
-        'dotenv',
+        'python-dotenv',
     ],
     extras_require={
         # Extra dependencies for RAG:


### PR DESCRIPTION
## Summary

- Fix incorrect package name `dotenv` → `python-dotenv` in `setup.py` install_requires

## Problem

`setup.py` lists `'dotenv'` as a dependency, but the code uses:

```python
from dotenv import load_dotenv  # qwen_agent/tools/mcp_manager.py:25
```

The `dotenv` and `python-dotenv` are **different packages** on PyPI:

| Package | PyPI | Provides `from dotenv import load_dotenv` |
|---------|------|------------------------------------------|
| `python-dotenv` | [link](https://pypi.org/project/python-dotenv/) | Yes (standard, 40M+ downloads/month) |
| `dotenv` | [link](https://pypi.org/project/dotenv/) | No (different API, <10K downloads/month) |

Running `pip install dotenv` installs the wrong package, which does not provide `load_dotenv`.

## Solution

Change `'dotenv'` to `'python-dotenv'` in `install_requires`.

## Test Plan

- [ ] `pip install python-dotenv && python -c "from dotenv import load_dotenv; print('OK')"`
- [ ] `pip install qwen-agent` resolves correctly