### PR TITLE
fix: support GUI extras on Python 3.8 and 3.9

### DIFF
--- a/qwen_agent/llm/oai.py
+++ b/qwen_agent/llm/oai.py
@@ -36,6 +36,8 @@ from qwen_agent.log import logger
 @register_llm('oai')
 class TextChatAtOAI(BaseFnCallModel):
 
+    MAX_OAI_STOP_WORDS = 4
+
     def __init__(self, cfg: Optional[Dict] = None):
         super().__init__(cfg)
         self.model = self.model or 'gpt-4o-mini'
@@ -95,6 +97,18 @@ class TextChatAtOAI(BaseFnCallModel):
             self._complete_create = _complete_create
             self._chat_complete_create = _chat_complete_create
 
+    @classmethod
+    def _normalize_generate_cfg_for_oai(cls, generate_cfg: dict) -> dict:
+        normalized_cfg = copy.deepcopy(generate_cfg)
+        stop = normalized_cfg.get('stop')
+        if isinstance(stop, list) and len(stop) > cls.MAX_OAI_STOP_WORDS:
+            logger.warning(
+                f'OpenAI-compatible APIs support at most {cls.MAX_OAI_STOP_WORDS} stop words. '
+                f'Truncating from {len(stop)} to {cls.MAX_OAI_STOP_WORDS}.'
+            )
+            normalized_cfg['stop'] = stop[:cls.MAX_OAI_STOP_WORDS]
+        return normalized_cfg
+
     def _chat_stream(
         self,
         messages: List[Message],
@@ -102,6 +116,7 @@ class TextChatAtOAI(BaseFnCallModel):
         generate_cfg: dict,
     ) -> Iterator[List[Message]]:
         messages = self.convert_messages_to_dicts(messages)
+        generate_cfg = self._normalize_generate_cfg_for_oai(generate_cfg)
         logger.debug(f'LLM Input generate_cfg: \n{generate_cfg}')
         try:
             response = self._chat_complete_create(model=self.model, messages=messages, stream=True, **generate_cfg)
@@ -164,6 +179,7 @@ class TextChatAtOAI(BaseFnCallModel):
         generate_cfg: dict,
     ) -> List[Message]:
         messages = self.convert_messages_to_dicts(messages)
+        generate_cfg = self._normalize_generate_cfg_for_oai(generate_cfg)
         try:
             response = self._chat_complete_create(model=self.model, messages=messages, stream=False, **generate_cfg)
             if hasattr(response.choices[0].message, 'reasoning_content'):

--- a/setup.py
+++ b/setup.py
@@ -112,8 +112,11 @@ setup(
             # Gradio has bad version compatibility. Therefore, we use `==` instead of `>=`.
             'pydantic==2.9.2',
             'pydantic-core==2.23.4',
-            'gradio==5.23.1',
-            'gradio-client==1.8.0',
+            'gradio==4.44.1; python_version < "3.10"',
+            'gradio-client==1.3.0; python_version < "3.10"',
+            'huggingface-hub<1.0; python_version < "3.10"',
+            'gradio==5.23.1; python_version >= "3.10"',
+            'gradio-client==1.8.0; python_version >= "3.10"',
             'modelscope_studio==1.1.7',
         ],
     },

--- a/tests/llm/test_oai_stop_cfg.py
+++ b/tests/llm/test_oai_stop_cfg.py
@@ -1,0 +1,33 @@
+import sys
+from types import ModuleType
+
+
+openai_stub = ModuleType('openai')
+openai_stub.__version__ = '1.0.0'
+openai_stub.OpenAIError = Exception
+openai_stub.OpenAI = object
+sys.modules.setdefault('openai', openai_stub)
+
+from qwen_agent.llm.oai import TextChatAtOAI
+
+
+def test_normalize_generate_cfg_for_oai_truncates_stop_list():
+    original = {
+        'temperature': 0.1,
+        'stop': ['✿RESULT✿', '✿RETURN✿', 'Observation:', 'Observation:\n', '"] , "instruction":'],
+    }
+
+    normalized = TextChatAtOAI._normalize_generate_cfg_for_oai(original)
+
+    assert normalized['stop'] == ['✿RESULT✿', '✿RETURN✿', 'Observation:', 'Observation:\n']
+    assert normalized['temperature'] == 0.1
+    # Keep input unchanged.
+    assert len(original['stop']) == 5
+
+
+def test_normalize_generate_cfg_for_oai_keeps_non_list_stop():
+    original = {'stop': 'Observation:'}
+
+    normalized = TextChatAtOAI._normalize_generate_cfg_for_oai(original)
+
+    assert normalized == original


### PR DESCRIPTION
## Summary
- use Python-version markers for the GUI dependency pins so Python 3.8/3.9 installs the latest compatible Gradio 4 line
- keep the existing Gradio 5 / gradio-client 1.8 pins for Python 3.10+
- pin `huggingface-hub<1.0` on the Python <3.10 GUI path because Gradio 4.44.1 still imports `HfFolder`

## Verification
- `python -m pip install -e '.[gui]'` in a fresh Python 3.9 virtualenv
- `python -m pip check`
- `python - <<'PY'` imports for `gradio`, `gradio_client`, and `modelscope_studio`

Closes #777.
