### PR TITLE
fix: add threading lock to MCPManager singleton

### DIFF
--- a/qwen_agent/tools/mcp_manager.py
+++ b/qwen_agent/tools/mcp_manager.py
@@ -30,10 +30,14 @@ from qwen_agent.tools.base import BaseTool
 
 class MCPManager:
     _instance = None  # Private class variable to store the unique instance
+    _instance_lock = threading.Lock()  # Lock to protect singleton instantiation
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
-            cls._instance = super(MCPManager, cls).__new__(cls, *args, **kwargs)
+            with cls._instance_lock:
+                # Double-checked locking: re-check after acquiring the lock
+                if cls._instance is None:
+                    cls._instance = super(MCPManager, cls).__new__(cls, *args, **kwargs)
         return cls._instance
 
     def __init__(self):


### PR DESCRIPTION
## Problem

`MCPManager.__new__()` checks `cls._instance is None` without holding a lock:

```python
def __new__(cls, *args, **kwargs):
    if cls._instance is None:
        cls._instance = super(MCPManager, cls).__new__(cls, *args, **kwargs)
    return cls._instance
```

Two threads can both evaluate `cls._instance is None` as `True` before either has assigned the instance, causing both to call `super().__new__()` and create separate instances. This breaks the singleton guarantee and can result in duplicate event loops, duplicate `self.clients` dicts, and split state between callers.

## Fix

Add a class-level `threading.Lock` (`_instance_lock`) and use double-checked locking in `__new__`:

- The **outer** `if cls._instance is None` avoids acquiring the lock on every call after initialization (hot-path performance).
- The **inner** `if cls._instance is None` inside `with cls._instance_lock` prevents a second thread from creating a duplicate after the first thread completes assignment.

`threading` was already imported in this module, so no new dependency is introduced.

Fixes #812