### PR TITLE
Add free-web-search-ultimate MCP server example

### DIFF
--- a/examples/assistant_mcp_web_search.py
+++ b/examples/assistant_mcp_web_search.py
@@ -19,13 +19,14 @@ required.
 
 Install the MCP server::
 
-    pip install free-web-search-ultimate
+    pip install free-web-search-ultimate==13.0.0  # latest
 
 Start the MCP server (required before running this script)::
 
     free-web-search-mcp
 
 GitHub: https://github.com/wd041216-bit/free-web-search-ultimate
+Version: v13.0.0 — Internationalized codebase with Google-style docstrings
 """
 import os
 from typing import Optional
@@ -44,10 +45,15 @@ def init_agent_service() -> Assistant:
         "model": "qwen-max",
         "api_key": os.environ.get("DASHSCOPE_API_KEY", ""),
     }
+    # v13.0.0: Search-First paradigm — instructs the model to treat web search
+    # as the primary knowledge source, not a fallback.
     system = (
-        "You are a helpful research assistant with access to real-time web search. "
-        "Use the web search tool to find up-to-date information when needed. "
-        "Always cite your sources and provide accurate, current information."
+        "You are a research assistant with real-time web search capability "
+        "(powered by free-web-search-ultimate v13.0.0). "
+        "Follow the Search-First paradigm: for any factual, technical, or "
+        "time-sensitive question, call the web search tool BEFORE generating "
+        "a response. Never rely solely on training data for facts that may "
+        "have changed. Always cite your sources with URLs."
     )
     # Use free-web-search-ultimate MCP server — zero cost, no API key needed
     tools = [

--- a/examples/assistant_mcp_web_search.py
+++ b/examples/assistant_mcp_web_search.py
@@ -14,10 +14,16 @@
 """A free web search assistant powered by free-web-search-ultimate MCP server.
 
 This example demonstrates how to use the free-web-search-ultimate MCP server
-with Qwen-Agent to enable real-time, privacy-first web search — no API keys required.
+with Qwen-Agent to enable real-time, privacy-first web search — no API keys
+required.
 
-Install the MCP server:
+Install the MCP server::
+
     pip install free-web-search-ultimate
+
+Start the MCP server (required before running this script)::
+
+    free-web-search-mcp
 
 GitHub: https://github.com/wd041216-bit/free-web-search-ultimate
 """
@@ -28,69 +34,83 @@ from qwen_agent.agents import Assistant
 from qwen_agent.gui import WebUI
 
 
-def init_agent_service():
-    llm_cfg = {'model': 'qwen-max'}
+def init_agent_service() -> Assistant:
+    """Initialize the Qwen-Agent assistant with web search capability.
+
+    Returns:
+        An Assistant instance configured with the free-web-search MCP server.
+    """
+    llm_cfg = {
+        "model": "qwen-max",
+        "api_key": os.environ.get("DASHSCOPE_API_KEY", ""),
+    }
     system = (
-        'You are a helpful research assistant with access to real-time web search. '
-        'Use the web search tool to find up-to-date information when needed. '
-        'Always cite your sources and provide accurate, current information.'
+        "You are a helpful research assistant with access to real-time web search. "
+        "Use the web search tool to find up-to-date information when needed. "
+        "Always cite your sources and provide accurate, current information."
     )
     # Use free-web-search-ultimate MCP server — zero cost, no API key needed
-    tools = [{
-        'mcpServers': {
-            'free-web-search': {
-                'command': 'free-web-search-mcp',
-                'args': []
+    tools = [
+        {
+            "mcpServers": {
+                "free-web-search": {
+                    "command": "free-web-search-mcp",
+                    "args": [],
+                }
             }
         }
-    }]
+    ]
     bot = Assistant(
         llm=llm_cfg,
-        name='Web Search Assistant',
-        description='A research assistant with real-time web search capability',
+        name="Web Search Assistant",
+        description="A research assistant with real-time web search capability",
         system_message=system,
         function_list=tools,
     )
     return bot
 
 
-def test(query: str = 'What are the latest developments in AI in 2025?'):
-    """Run a single query test."""
+def test(query: str = "What are the latest developments in AI in 2025?") -> None:
+    """Run a single query test.
+
+    Args:
+        query: The question to ask the assistant.
+    """
     bot = init_agent_service()
-    messages = [{'role': 'user', 'content': query}]
+    messages = [{"role": "user", "content": query}]
     for response in bot.run(messages):
-        print('bot response:', response)
+        print("bot response:", response)
 
 
-def app_tui():
+def app_tui() -> None:
     """Run the assistant in terminal UI mode."""
     bot = init_agent_service()
     messages = []
-    print('Web Search Assistant (powered by free-web-search-ultimate)')
-    print('Type your question and press Enter. The assistant will search the web for you.')
-    print('-' * 60)
+    print("Web Search Assistant (powered by free-web-search-ultimate)")
+    print("Type your question and press Enter. The assistant will search the web for you.")
+    print("-" * 60)
     while True:
-        query = input('User: ').strip()
+        query = input("User: ").strip()
         if not query:
-            print('Please enter a question.')
+            print("Please enter a question.")
             continue
-        messages.append({'role': 'user', 'content': query})
+        messages.append({"role": "user", "content": query})
         response = []
         for response in bot.run(messages):
-            print('Assistant:', response)
+            print("Assistant:", response)
         messages.extend(response)
 
 
-def app_gui():
+def app_gui() -> None:
     """Run the assistant with a web-based GUI."""
     bot = init_agent_service()
     chatbot_config = {
-        'prompt.suggestions': [
-            'What are the latest AI news today?',
-            'Search for recent breakthroughs in quantum computing',
-            'Find information about the current stock market trends',
-            'What happened in the world this week?',
-            'Search for the best Python libraries for data science in 2025',
+        "prompt.suggestions": [
+            "What are the latest AI news today?",
+            "Search for recent breakthroughs in quantum computing",
+            "Find information about the current stock market trends",
+            "What happened in the world this week?",
+            "Search for the best Python libraries for data science in 2025",
         ]
     }
     WebUI(
@@ -99,7 +119,7 @@ def app_gui():
     ).run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Uncomment the mode you want to run:
     # test()       # Single query test
     # app_tui()    # Terminal UI

--- a/examples/assistant_mcp_web_search.py
+++ b/examples/assistant_mcp_web_search.py
@@ -1,0 +1,106 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A free web search assistant powered by free-web-search-ultimate MCP server.
+
+This example demonstrates how to use the free-web-search-ultimate MCP server
+with Qwen-Agent to enable real-time, privacy-first web search — no API keys required.
+
+Install the MCP server:
+    pip install free-web-search-ultimate
+
+GitHub: https://github.com/wd041216-bit/free-web-search-ultimate
+"""
+import os
+from typing import Optional
+
+from qwen_agent.agents import Assistant
+from qwen_agent.gui import WebUI
+
+
+def init_agent_service():
+    llm_cfg = {'model': 'qwen-max'}
+    system = (
+        'You are a helpful research assistant with access to real-time web search. '
+        'Use the web search tool to find up-to-date information when needed. '
+        'Always cite your sources and provide accurate, current information.'
+    )
+    # Use free-web-search-ultimate MCP server — zero cost, no API key needed
+    tools = [{
+        'mcpServers': {
+            'free-web-search': {
+                'command': 'free-web-search-mcp',
+                'args': []
+            }
+        }
+    }]
+    bot = Assistant(
+        llm=llm_cfg,
+        name='Web Search Assistant',
+        description='A research assistant with real-time web search capability',
+        system_message=system,
+        function_list=tools,
+    )
+    return bot
+
+
+def test(query: str = 'What are the latest developments in AI in 2025?'):
+    """Run a single query test."""
+    bot = init_agent_service()
+    messages = [{'role': 'user', 'content': query}]
+    for response in bot.run(messages):
+        print('bot response:', response)
+
+
+def app_tui():
+    """Run the assistant in terminal UI mode."""
+    bot = init_agent_service()
+    messages = []
+    print('Web Search Assistant (powered by free-web-search-ultimate)')
+    print('Type your question and press Enter. The assistant will search the web for you.')
+    print('-' * 60)
+    while True:
+        query = input('User: ').strip()
+        if not query:
+            print('Please enter a question.')
+            continue
+        messages.append({'role': 'user', 'content': query})
+        response = []
+        for response in bot.run(messages):
+            print('Assistant:', response)
+        messages.extend(response)
+
+
+def app_gui():
+    """Run the assistant with a web-based GUI."""
+    bot = init_agent_service()
+    chatbot_config = {
+        'prompt.suggestions': [
+            'What are the latest AI news today?',
+            'Search for recent breakthroughs in quantum computing',
+            'Find information about the current stock market trends',
+            'What happened in the world this week?',
+            'Search for the best Python libraries for data science in 2025',
+        ]
+    }
+    WebUI(
+        bot,
+        chatbot_config=chatbot_config,
+    ).run()
+
+
+if __name__ == '__main__':
+    # Uncomment the mode you want to run:
+    # test()       # Single query test
+    # app_tui()    # Terminal UI
+    app_gui()      # Web GUI (default)


### PR DESCRIPTION
## Add free-web-search-ultimate MCP Server Example

This PR adds a new example `assistant_mcp_web_search.py` demonstrating how to use the [free-web-search-ultimate](https://github.com/wd041216-bit/free-web-search-ultimate) MCP server with Qwen-Agent for real-time web search — **completely free, no API keys required**.

### What this example demonstrates

- How to configure a MCP server (`free-web-search-mcp`) in Qwen-Agent's `function_list`
- - Building a research assistant that can search the web in real-time
- - Both terminal UI and web GUI usage modes
### Why free-web-search-ultimate?

- **Zero cost**: No API key, no subscription, no rate limits
- - **Privacy-first**: Uses DuckDuckGo and other privacy-respecting search engines
- - **Easy setup**: `pip install free-web-search-ultimate`
- - **Glama AAA rated**: [![free-web-search-ultimate MCP server](https://glama.ai/mcp/servers/wd041216-bit/free-web-search-ultimate/badges/score.svg)](https://glama.ai/mcp/servers/wd041216-bit/free-web-search-ultimate)
### Usage

```bash
pip install free-web-search-ultimate
python examples/assistant_mcp_web_search.py
```