### PR TITLE
fix: add timeout to MCP tool future.result() to prevent indefinite bl…

### DIFF
--- a/qwen_agent/tools/mcp_manager.py
+++ b/qwen_agent/tools/mcp_manager.py
@@ -277,8 +277,12 @@ class MCPManager:
                 client = manager.clients[self.client_id]
                 future = asyncio.run_coroutine_threadsafe(client.execute_function(tool_name, tool_args), manager.loop)
                 try:
-                    result = future.result()
+                    result = future.result(timeout=60)
                     return result
+                except TimeoutError:
+                    future.cancel()
+                    logger.warning(f'MCP tool "{tool_name}" timed out after 60s')
+                    raise RuntimeError(f'MCP tool "{tool_name}" timed out after 60s')
                 except Exception as e:
                     logger.info(f'Failed in executing MCP tool: {e}')
                     raise e


### PR DESCRIPTION
## Bug: `MCPManager` tool calls block indefinitely when MCP server hangs

### Summary

When an MCP server becomes unresponsive during a tool call, the `ToolClass.call()` method in `mcp_manager.py` blocks the calling thread indefinitely. This causes worker threads to remain permanently active, consuming CPU resources until the process is manually killed.

### Root Cause

In `create_tool_class()`, the result of the async tool call future is awaited with no timeout:

```python
future = asyncio.run_coroutine_threadsafe(client.execute_function(tool_name, tool_args), manager.loop)
try:
    result = future.result()  # blocks forever if the coroutine never resolves
    return result
```

If the underlying MCP server stalls (slow HTTP request, hung subprocess, failed SSE connection, DNS/SSL issue, etc.) the coroutine in `execute_function` never resolves, and `future.result()` waits indefinitely. The thread pool worker that called the tool is permanently blocked, and because it holds a reference to the event loop, it also prevents clean shutdown.

### Observed Symptoms

- `concurrent.futures` thread pool workers stuck in `_worker` and marked `active` in process monitors indefinitely
- Python process pegged at 100% CPU on one or more threads for hours with no forward progress
- Process does not respond to normal shutdown; requires `SIGKILL`
- `py-spy dump` shows all active threads blocked inside `future.result()` with no further stack progression

### Fix

Add a `timeout` parameter to `future.result()` and cancel the future on timeout