### PR TITLE
fix(dependencies): replace 'dotenv' with 'python-dotenv'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'requests',
         'tiktoken',
         'pillow',
-        'dotenv',
+        'python-dotenv',
     ],
     extras_require={
         # Extra dependencies for RAG:


### PR DESCRIPTION
## Summary

- Replace `'dotenv'` with `'python-dotenv'` in `install_requires`
- The pip package name is `python-dotenv`, not `dotenv`

## Fixes

Fixes #837

## Test

Verified that `from dotenv import load_dotenv` works with `python-dotenv` (the module exposes `dotenv` as an alias).

---

*Contribution by abdelhadisalmaoui0909@outlook.fr*