### PR TITLE
fix(llm): support 'reasoning' field from Ollama in streaming responses

### DIFF
--- a/qwen_agent/llm/oai.py
+++ b/qwen_agent/llm/oai.py
@@ -108,26 +108,26 @@ class TextChatAtOAI(BaseFnCallModel):
             if delta_stream:
                 for chunk in response:
                     if chunk.choices:
-                        if hasattr(chunk.choices[0].delta,
-                                   'reasoning_content') and chunk.choices[0].delta.reasoning_content:
-                            yield [
-                                Message(role=ASSISTANT,
-                                        content='',
-                                        reasoning_content=chunk.choices[0].delta.reasoning_content)
-                            ]
-                        if hasattr(chunk.choices[0].delta, 'content') and chunk.choices[0].delta.content:
-                            yield [Message(role=ASSISTANT, content=chunk.choices[0].delta.content)]
+                        delta = chunk.choices[0].delta
+                        # Support both 'reasoning_content' (vLLM/Qwen) and 'reasoning' (Ollama) fields
+                        reasoning = getattr(delta, 'reasoning_content', None) or getattr(delta, 'reasoning', None)
+                        if reasoning:
+                            yield [Message(role=ASSISTANT, content='', reasoning_content=reasoning)]
+                        if getattr(delta, 'content', None):
+                            yield [Message(role=ASSISTANT, content=delta.content)]
             else:
                 full_response = ''
                 full_reasoning_content = ''
                 full_tool_calls = []
                 for chunk in response:
                     if chunk.choices:
-                        if hasattr(chunk.choices[0].delta,
-                                   'reasoning_content') and chunk.choices[0].delta.reasoning_content:
-                            full_reasoning_content += chunk.choices[0].delta.reasoning_content
-                        if hasattr(chunk.choices[0].delta, 'content') and chunk.choices[0].delta.content:
-                            full_response += chunk.choices[0].delta.content
+                        delta = chunk.choices[0].delta
+                        # Support both 'reasoning_content' (vLLM/Qwen) and 'reasoning' (Ollama) fields
+                        reasoning = getattr(delta, 'reasoning_content', None) or getattr(delta, 'reasoning', None)
+                        if reasoning:
+                            full_reasoning_content += reasoning
+                        if getattr(delta, 'content', None):
+                            full_response += delta.content
                         if hasattr(chunk.choices[0].delta, 'tool_calls') and chunk.choices[0].delta.tool_calls:
                             for tc in chunk.choices[0].delta.tool_calls:
                                 if full_tool_calls and (not tc.id or


### PR DESCRIPTION
## Summary

Fix streaming responses from Ollama where thinking content is silently lost.

**Problem**: Ollama sends `delta.reasoning` for Qwen3 models with thinking content, but the streaming code only checked for `delta.reasoning_content` (used by vLLM/Qwen API).

**Fix**: Use `getattr()` to check both field names — `reasoning_content` (vLLM/Qwen) and `reasoning` (Ollama) — in both streaming modes (delta yield and full accumulation).

## Changes

- `qwen_agent/llm/oai.py`: Updated `_chat_stream()` to handle both field names

## Test

Verified that both `reasoning_content` (vLLM) and `reasoning` (Ollama) are now correctly captured.

---

*Contribution by abdelhadisalmaoui0909@outlook.fr*