### PR TITLE
fix(gui): escape bot_name and bot_description to prevent XSS

### DIFF
--- a/qwen_agent/gui/gradio_utils.py
+++ b/qwen_agent/gui/gradio_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import base64
+import html
 
 
 def covert_image_to_base64(image_path):
@@ -74,7 +75,7 @@ def format_cover_html(bot_name, bot_description, bot_avatar):
     <div class="bot_avatar">
         <img src="{image_src}" />
     </div>
-    <div class="bot_name">{bot_name}</div>
-    <div class="bot_desp">{bot_description}</div>
+    <div class="bot_name">{html.escape(bot_name)}</div>
+    <div class="bot_desp">{html.escape(bot_description)}</div>
 </div>
 """


### PR DESCRIPTION
## Summary

Prevent XSS attacks via unsanitized `bot_name` and `bot_description` in the Gradio WebUI.

**Problem**: `bot_name` and `bot_description` are interpolated directly into HTML in `format_cover_html()` without escaping, allowing a malicious user to inject JavaScript (e.g. `<img src=x onerror=alert(document.cookie)>`).

**Fix**: Apply `html.escape()` to both fields before HTML interpolation.

## Changes

- `qwen_agent/gui/gradio_utils.py`:
  - Add `import html`
  - Escape `bot_name` and `bot_description` with `html.escape()`

## Security

- [x] Prevents stored XSS via bot configuration
- [x] Uses Python stdlib (`html.escape`) — no new dependencies

---

*Contribution by abdelhadisalmaoui0909@outlook.fr*