### PR TITLE
fix(tools): add thread-safe lock to MCPManager singleton

### DIFF
--- a/qwen_agent/tools/mcp_manager.py
+++ b/qwen_agent/tools/mcp_manager.py
@@ -30,10 +30,12 @@ from qwen_agent.tools.base import BaseTool
 
 class MCPManager:
     _instance = None  # Private class variable to store the unique instance
+    _lock = threading.Lock()  # Lock to ensure thread-safe singleton creation
 
     def __new__(cls, *args, **kwargs):
-        if cls._instance is None:
-            cls._instance = super(MCPManager, cls).__new__(cls, *args, **kwargs)
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super(MCPManager, cls).__new__(cls, *args, **kwargs)
         return cls._instance
 
     def __init__(self):


### PR DESCRIPTION
## Summary

Add thread-safety to the `MCPManager` singleton pattern.

**Problem**: The singleton used `__new__` without a mutex lock. In multi-threaded environments, two threads can simultaneously evaluate `cls._instance is None` before either creates the instance, resulting in two instances being created and breaking the singleton pattern.

**Fix**: Add `threading.Lock()` as a class variable and wrap the instance creation in a `with cls._lock:` block.

## Changes

- `qwen_agent/tools/mcp_manager.py`:
  - Add `_lock = threading.Lock()` class variable
  - Wrap singleton creation in `with cls._lock:`

## Security/Reliability

- [x] Prevents race conditions in multi-threaded environments
- [x] No new dependencies — `threading` is part of Python stdlib
- [x] `threading` is already imported in the file

---

*Contribution by abdelhadisalmaoui0909@outlook.fr*