### PR TITLE
fix: use python-dotenv instead of dotenv in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'requests',
         'tiktoken',
         'pillow',
-        'dotenv',
+        'python-dotenv',
     ],
     extras_require={
         # Extra dependencies for RAG:


### PR DESCRIPTION
## Summary
- replace  with  in 
- align dependency name with the imported module and PyPI package used by the project

## Why
 currently installs , which can cause runtime import failures for  on clean installs. This addresses #837.

Closes #837