### PR TITLE
fix(gui): escape bot metadata in cover html

### DIFF
--- a/qwen_agent/gui/gradio_utils.py
+++ b/qwen_agent/gui/gradio_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import base64
+import html
 
 
 def covert_image_to_base64(image_path):
@@ -32,6 +33,9 @@ def covert_image_to_base64(image_path):
 
 
 def format_cover_html(bot_name, bot_description, bot_avatar):
+    safe_bot_name = html.escape(bot_name or '')
+    safe_bot_description = html.escape(bot_description or '')
+
     if bot_avatar:
         image_src = covert_image_to_base64(bot_avatar)
     else:
@@ -74,7 +78,7 @@ def format_cover_html(bot_name, bot_description, bot_avatar):
     <div class="bot_avatar">
         <img src="{image_src}" />
     </div>
-    <div class="bot_name">{bot_name}</div>
-    <div class="bot_desp">{bot_description}</div>
+    <div class="bot_name">{safe_bot_name}</div>
+    <div class="bot_desp">{safe_bot_description}</div>
 </div>
 """


### PR DESCRIPTION
## Summary
- escape `bot_name` and `bot_description` before interpolating into HTML in `format_cover_html`
- preserve current UI behavior while preventing script/HTML injection in WebUI cover blocks

## Why
`bot_name` and `bot_description` may come from user-controlled config. Rendering raw values into HTML can lead to XSS in Gradio-based WebUI pages.

Closes #810
