### PR TITLE
docs: add dotenv import troubleshooting in install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ pip install -U "qwen-agent[gui,rag,code_interpreter,mcp]"
 #   [mcp] for MCP support.
 ```
 
+If you encounter `ModuleNotFoundError: No module named 'dotenv'` on an existing environment, run:
+```bash
+pip install -U python-dotenv
+```
+
 - Alternatively, you can install the latest development version from the source:
 ```bash
 git clone https://github.com/QwenLM/Qwen-Agent.git

--- a/qwen-agent-docs/website/content/en/guide/get_started/install.md
+++ b/qwen-agent-docs/website/content/en/guide/get_started/install.md
@@ -11,6 +11,11 @@ pip install -U "qwen-agent[gui,rag,code_interpreter,mcp]"
 #   [mcp] for MCP support.
 ```
 
+If you encounter `ModuleNotFoundError: No module named 'dotenv'` on an existing environment, run:
+```bash
+pip install -U python-dotenv
+```
+
 - Alternatively, you can install the latest development version from the source:
 ```bash
 git clone https://github.com/QwenLM/Qwen-Agent.git


### PR DESCRIPTION
## Summary
- add a short troubleshooting note in installation docs for `ModuleNotFoundError: No module named 'dotenv'`
- include a direct recovery command (`pip install -U python-dotenv`) in both README and docs site install guide

## Why
This addresses a common install/runtime confusion reported in #837 and helps users recover quickly in existing environments.

Refs #837
