### PR TITLE
feat: add [ LiteLLM AI gateway ]

### DIFF
--- a/qwen_agent/llm/__init__.py
+++ b/qwen_agent/llm/__init__.py
@@ -17,6 +17,7 @@ from typing import Union
 
 from .azure import TextChatAtAzure
 from .base import LLM_REGISTRY, BaseChatModel, ModelServiceError
+from .litellm import TextChatAtLiteLLM
 from .oai import TextChatAtOAI
 from .openvino import OpenVINO
 from .qwen_dashscope import QwenChatAtDS
@@ -105,6 +106,7 @@ __all__ = [
     'QwenChatAtDS',
     'TextChatAtOAI',
     'TextChatAtAzure',
+    'TextChatAtLiteLLM',
     'QwenVLChatAtDS',
     'QwenVLChatAtOAI',
     'QwenAudioChatAtDS',

--- a/qwen_agent/llm/litellm.py
+++ b/qwen_agent/llm/litellm.py
@@ -1,0 +1,159 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""LiteLLM provider — unified access to 100+ LLM providers via the LiteLLM AI gateway.
+
+Route chat completions through ``litellm.completion()`` using prefixed model names
+(e.g. ``anthropic/claude-3-5-sonnet-20241022``, ``gemini/gemini-1.5-pro``,
+``bedrock/anthropic.claude-3-sonnet-20240229-v1:0``). See
+https://docs.litellm.ai/docs/providers for the full provider list.
+"""
+import logging
+from pprint import pformat
+from typing import Dict, Iterator, List, Optional
+
+from qwen_agent.llm.base import ModelServiceError, register_llm
+from qwen_agent.llm.function_calling import BaseFnCallModel
+from qwen_agent.llm.schema import ASSISTANT, FunctionCall, Message
+from qwen_agent.log import logger
+from qwen_agent.utils.utils import format_as_text_message
+
+
+@register_llm('litellm')
+class TextChatAtLiteLLM(BaseFnCallModel):
+    """LiteLLM-backed provider.
+
+    Configuration example::
+
+        cfg = {
+            'model': 'anthropic/claude-3-5-sonnet-20241022',  # LiteLLM-style prefix
+            'model_type': 'litellm',
+            'api_key': '<provider-api-key>',  # optional; env vars also work
+        }
+    """
+
+    def __init__(self, cfg: Optional[Dict] = None):
+        super().__init__(cfg)
+        self.model = self.model or 'openai/gpt-4o-mini'
+        cfg = cfg or {}
+
+        api_base = cfg.get('api_base') or cfg.get('base_url') or cfg.get('model_server')
+        self._api_base = (api_base or '').strip() or None
+
+        api_key = cfg.get('api_key')
+        self._api_key = api_key.strip() if isinstance(api_key, str) and api_key.strip() else None
+
+    def _call_kwargs(self, messages: List[dict], generate_cfg: dict, stream: bool) -> dict:
+        kwargs = {
+            'model': self.model,
+            'messages': messages,
+            'stream': stream,
+        }
+        if self._api_key:
+            kwargs['api_key'] = self._api_key
+        if self._api_base:
+            kwargs['api_base'] = self._api_base
+        kwargs.update(generate_cfg)
+        # Qwen-Agent passes `request_timeout`; LiteLLM expects `timeout`.
+        if 'request_timeout' in kwargs:
+            kwargs['timeout'] = kwargs.pop('request_timeout')
+        return kwargs
+
+    def _chat_stream(
+        self,
+        messages: List[Message],
+        delta_stream: bool,
+        generate_cfg: dict,
+    ) -> Iterator[List[Message]]:
+        import litellm
+        from litellm.exceptions import APIError
+
+        messages = self.convert_messages_to_dicts(messages)
+        logger.debug(f'LLM Input generate_cfg: \n{generate_cfg}')
+        try:
+            response = litellm.completion(**self._call_kwargs(messages, generate_cfg, stream=True))
+            if delta_stream:
+                for chunk in response:
+                    if not chunk.choices:
+                        continue
+                    delta = chunk.choices[0].delta
+                    if hasattr(delta, 'reasoning_content') and delta.reasoning_content:
+                        yield [Message(role=ASSISTANT, content='', reasoning_content=delta.reasoning_content)]
+                    if hasattr(delta, 'content') and delta.content:
+                        yield [Message(role=ASSISTANT, content=delta.content)]
+            else:
+                full_response = ''
+                full_reasoning_content = ''
+                full_tool_calls: List[Message] = []
+                for chunk in response:
+                    if not chunk.choices:
+                        continue
+                    delta = chunk.choices[0].delta
+                    if hasattr(delta, 'reasoning_content') and delta.reasoning_content:
+                        full_reasoning_content += delta.reasoning_content
+                    if hasattr(delta, 'content') and delta.content:
+                        full_response += delta.content
+                    if hasattr(delta, 'tool_calls') and delta.tool_calls:
+                        for tc in delta.tool_calls:
+                            if full_tool_calls and (not tc.id or
+                                                    tc.id == full_tool_calls[-1].extra.get('function_id')):
+                                if tc.function.name:
+                                    full_tool_calls[-1].function_call.name += tc.function.name
+                                if tc.function.arguments:
+                                    full_tool_calls[-1].function_call.arguments += tc.function.arguments
+                            else:
+                                full_tool_calls.append(
+                                    Message(role=ASSISTANT,
+                                            content='',
+                                            function_call=FunctionCall(name=tc.function.name or '',
+                                                                       arguments=tc.function.arguments or ''),
+                                            extra={'function_id': tc.id}))
+
+                    res: List[Message] = []
+                    if full_reasoning_content:
+                        res.append(Message(role=ASSISTANT, content='', reasoning_content=full_reasoning_content))
+                    if full_response:
+                        res.append(Message(role=ASSISTANT, content=full_response))
+                    if full_tool_calls:
+                        res += full_tool_calls
+                    yield res
+        except APIError as ex:
+            raise ModelServiceError(exception=ex)
+
+    def _chat_no_stream(
+        self,
+        messages: List[Message],
+        generate_cfg: dict,
+    ) -> List[Message]:
+        import litellm
+        from litellm.exceptions import APIError
+
+        messages = self.convert_messages_to_dicts(messages)
+        try:
+            response = litellm.completion(**self._call_kwargs(messages, generate_cfg, stream=False))
+            msg = response.choices[0].message
+            content = getattr(msg, 'content', '') or ''
+            reasoning = getattr(msg, 'reasoning_content', None)
+            if reasoning:
+                return [Message(role=ASSISTANT, content=content, reasoning_content=reasoning)]
+            return [Message(role=ASSISTANT, content=content)]
+        except APIError as ex:
+            raise ModelServiceError(exception=ex)
+
+    def convert_messages_to_dicts(self, messages: List[Message]) -> List[dict]:
+        messages = [format_as_text_message(msg, add_upload_info=False) for msg in messages]
+        messages = [msg.model_dump() for msg in messages]
+        messages = self._conv_qwen_agent_messages_to_oai(messages)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f'LLM Input: \n{pformat(messages, indent=2)}')
+        return messages

--- a/qwen_agent/llm/litellm.py
+++ b/qwen_agent/llm/litellm.py
@@ -58,6 +58,14 @@ class TextChatAtLiteLLM(BaseFnCallModel):
             'model': self.model,
             'messages': messages,
             'stream': stream,
+            # Qwen-Agent's base class always injects `seed` into generate_cfg, and
+            # fncall_prompts adds `stop=['<|im_end|>', ...]` in some paths. These
+            # kwargs are fine for OpenAI/Azure but throw UnsupportedParamsError on
+            # other backends (e.g. Claude via Vertex, reported in issue #574).
+            # `drop_params=True` tells LiteLLM to silently drop per-provider-
+            # unsupported kwargs instead of raising. This is what the user in
+            # #574 manually enabled on their LiteLLM proxy.
+            'drop_params': True,
         }
         if self._api_key:
             kwargs['api_key'] = self._api_key

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,9 @@ setup(
             'tabulate',
         ],
 
+        # Extra dependencies for LiteLLM AI gateway:
+        'litellm': ['litellm>=1.50.0'],
+
         # Extra dependencies for MCP:
         'mcp': ['mcp'],
 

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         ],
 
         # Extra dependencies for LiteLLM AI gateway:
-        'litellm': ['litellm>=1.50.0'],
+        'litellm': ['litellm>=1.60,<1.85'],
 
         # Extra dependencies for MCP:
         'mcp': ['mcp'],

--- a/tests/llm/test_litellm.py
+++ b/tests/llm/test_litellm.py
@@ -1,0 +1,94 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from qwen_agent.llm import get_chat_model
+from qwen_agent.llm.base import LLM_REGISTRY
+from qwen_agent.llm.litellm import TextChatAtLiteLLM
+from qwen_agent.llm.schema import Message
+
+
+def _non_stream_response(content: str = 'Hello from LiteLLM') -> SimpleNamespace:
+    """Build a fake LiteLLM ModelResponse-shaped object (OpenAI-compatible)."""
+    message = SimpleNamespace(content=content, reasoning_content=None)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice])
+
+
+def _stream_chunks(content: str = 'Hello from LiteLLM'):
+    """Yield OpenAI-compatible streaming chunks from LiteLLM."""
+    delta = SimpleNamespace(content=content, reasoning_content=None, tool_calls=None)
+    choice = SimpleNamespace(delta=delta)
+    yield SimpleNamespace(choices=[choice])
+
+
+def test_litellm_registered():
+    assert 'litellm' in LLM_REGISTRY
+    assert LLM_REGISTRY['litellm'] is TextChatAtLiteLLM
+
+
+def test_litellm_get_chat_model():
+    cfg = {'model': 'openai/gpt-4o-mini', 'model_type': 'litellm', 'api_key': 'sk-fake'}
+    llm = get_chat_model(cfg)
+    assert isinstance(llm, TextChatAtLiteLLM)
+    assert llm.model == 'openai/gpt-4o-mini'
+
+
+def test_litellm_call_kwargs_forwards_api_key_and_base():
+    cfg = {
+        'model': 'openrouter/meta-llama/llama-3-70b-instruct',
+        'model_type': 'litellm',
+        'api_key': 'sk-fake',
+        'api_base': 'https://my-proxy.example.com/v1',
+    }
+    llm = get_chat_model(cfg)
+    kwargs = llm._call_kwargs(messages=[{'role': 'user', 'content': 'hi'}], generate_cfg={}, stream=False)
+    assert kwargs['model'] == 'openrouter/meta-llama/llama-3-70b-instruct'
+    assert kwargs['api_key'] == 'sk-fake'
+    assert kwargs['api_base'] == 'https://my-proxy.example.com/v1'
+    assert kwargs['stream'] is False
+
+
+def test_litellm_no_stream(mocker):
+    mocker.patch('litellm.completion', return_value=_non_stream_response('pong'))
+    cfg = {'model': 'openai/gpt-4o-mini', 'model_type': 'litellm', 'api_key': 'sk-fake'}
+    llm = get_chat_model(cfg)
+    response = llm.chat(messages=[Message('user', 'ping')], stream=False)
+    assert response[-1]['content'] == 'pong'
+
+
+def test_litellm_stream(mocker):
+    mocker.patch('litellm.completion', return_value=_stream_chunks('streamed reply'))
+    cfg = {'model': 'openai/gpt-4o-mini', 'model_type': 'litellm', 'api_key': 'sk-fake'}
+    llm = get_chat_model(cfg)
+    final = list(llm.chat(messages=[Message('user', 'ping')], stream=True))[-1]
+    assert 'streamed reply' in final[-1]['content']
+
+
+@pytest.mark.skipif(not os.getenv('OPENAI_API_KEY'), reason='OPENAI_API_KEY not set')
+def test_litellm_integration_openai():
+    """Live integration smoke test — only runs when OPENAI_API_KEY is exported."""
+    cfg = {
+        'model': 'openai/gpt-4o-mini',
+        'model_type': 'litellm',
+        'api_key': os.getenv('OPENAI_API_KEY'),
+    }
+    llm = get_chat_model(cfg)
+    response = llm.chat(messages=[Message('user', 'Say "pong" and nothing else.')], stream=False)
+    assert isinstance(response[-1]['content'], str)
+    assert response[-1]['content'].strip() != ''

--- a/tests/llm/test_litellm.py
+++ b/tests/llm/test_litellm.py
@@ -64,6 +64,37 @@ def test_litellm_call_kwargs_forwards_api_key_and_base():
     assert kwargs['stream'] is False
 
 
+def test_litellm_call_kwargs_sets_drop_params_by_default():
+    """Qwen-Agent's base class always injects `seed` (base.py line 177) and some
+    fncall paths add `stop=[...]`. These kwargs are unsupported by Claude via
+    Vertex (see issue #574). `drop_params=True` tells LiteLLM to silently drop
+    per-provider-unsupported kwargs so the same config works across providers."""
+    cfg = {'model': 'anthropic/claude-3-5-sonnet-20241022', 'model_type': 'litellm', 'api_key': 'sk-fake'}
+    llm = get_chat_model(cfg)
+    kwargs = llm._call_kwargs(
+        messages=[{'role': 'user', 'content': 'hi'}],
+        generate_cfg={'seed': 42, 'temperature': 0.1},
+        stream=False,
+    )
+    assert kwargs['drop_params'] is True
+    # User-supplied generate_cfg values still flow through.
+    assert kwargs['seed'] == 42
+    assert kwargs['temperature'] == 0.1
+
+
+def test_litellm_call_kwargs_user_can_opt_out_of_drop_params():
+    """If a user explicitly passes drop_params=False in generate_cfg, their
+    choice wins (useful for debugging unsupported-kwarg errors)."""
+    cfg = {'model': 'openai/gpt-4o-mini', 'model_type': 'litellm', 'api_key': 'sk-fake'}
+    llm = get_chat_model(cfg)
+    kwargs = llm._call_kwargs(
+        messages=[{'role': 'user', 'content': 'hi'}],
+        generate_cfg={'drop_params': False},
+        stream=False,
+    )
+    assert kwargs['drop_params'] is False
+
+
 def test_litellm_no_stream(mocker):
     mocker.patch('litellm.completion', return_value=_non_stream_response('pong'))
     cfg = {'model': 'openai/gpt-4o-mini', 'model_type': 'litellm', 'api_key': 'sk-fake'}


### PR DESCRIPTION
 ---                                                                                                                                                                                                                                                                                                                                                                     
  Summary                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                          
  - Add TextChatAtLiteLLM provider in qwen_agent/llm/litellm.py, implementing BaseFnCallModel against litellm.completion() — routes chat completions through the LiteLLM AI gateway.                                                                                                                                                                                      
  - Register as 'litellm' in LLM_REGISTRY via the existing @register_llm decorator.                                                                                                                                                                                                                                                                                       
  - Add tests/llm/test_litellm.py with 7 mocked unit tests + 1 live integration test guarded by OPENAI_API_KEY.
  - Add optional litellm extra in setup.py.            
  - Set drop_params=True on every litellm.completion() call so Qwen-Agent's auto-injected seed (and other per-provider-unsupported kwargs) doesn't break Claude-via-Vertex, Gemini, etc.                                                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                          
  Changes                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                          
  - qwen_agent/llm/litellm.py — new TextChatAtLiteLLM(BaseFnCallModel) with sync _chat_stream / _chat_no_stream. Lazy-imports litellm inside methods (matches the diskcache pattern in base.py), so it's truly optional.                                                                                                                                                  
  - qwen_agent/llm/__init__.py — register import + __all__ entry.                                                                                                                                                                                                                                                                                                         
  - setup.py — adds 'litellm': ['litellm>=1.50.0'] under extras_require.                                                                                                                                                                                                                                                                                                  
  - tests/llm/test_litellm.py — mocked tests for registration, dispatcher wiring, kwargs mapping, streaming, and non-streaming; integration test gated on OPENAI_API_KEY. 
  -  set drop_params=True by default in _call_kwargs after a full-repo read revealed that base.py:177 unconditionally injects seed into generate_cfg, which is the exact param Claude-via-Vertex rejects. Two new tests cover the default-on behavior and the opt-out path.
  
  ## Usage and Behaviour
                                                                                                                                                                                                                                                                                                                                                                         
```
  $ pytest tests/llm/test_litellm.py -v
  tests/llm/test_litellm.py::test_litellm_registered PASSED                                                                                                                                                                                                                                                                                                               
  tests/llm/test_litellm.py::test_litellm_get_chat_model PASSED
  tests/llm/test_litellm.py::test_litellm_call_kwargs_forwards_api_key_and_base PASSED                                                                                                                                                                                                                                                                                    
  tests/llm/test_litellm.py::test_litellm_call_kwargs_sets_drop_params_by_default PASSED                                                                                                                                                                                                                                                                                  
  tests/llm/test_litellm.py::test_litellm_call_kwargs_user_can_opt_out_of_drop_params PASSED                                                                                                                                                                                                                                                                              
  tests/llm/test_litellm.py::test_litellm_no_stream PASSED                                                                                                                                                                                                                                                                                                                
  tests/llm/test_litellm.py::test_litellm_stream PASSED                                                                                                                                                                                                                                                                                                                   
  tests/llm/test_litellm.py::test_litellm_integration_openai SKIPPED (OPENAI_API_KEY not set)                                                                                                                                                                                                                                                                             
  =================== 7 passed, 1 skipped in 0.92s ===================                                                                                                                                                                                                                    
```                                  
No regression: all 64 cases in tests/llm/ still collect cleanly.   

 Live end-to-end smoke test against Azure OpenAI (azure/gpt-4o) on the final code:
 
 ```
   → model: azure/gpt-4o
                                                                                                                                                                                                                                                                                                                                                                          
  [Probe] _call_kwargs drop_params: True   
  [Probe] _call_kwargs seed (from generate_cfg): 42                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                          
  [Test 1] non-streaming chat: 'What is 2+2?'                                                                                                                                                                                                                                                                                                                             
    response: '4'                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                          
  [Test 2] streaming chat: 'What is 5+5?'
    final response: '10'                                                                                                                                                                                                                                                                                                                                                  
    total chunks: 2                                                                                                                                                                                                                                                                                                                                                       
                                        
  [Test 3] function-calling path (prompt-based via BaseFnCallModel)                                                                                                                                                                                                                                                                                                       
    function_call present: False        
    content: 'Understood! I will create an image of a red square for you.'                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                          
  Qwen-Agent LiteLLM live test PASSED (drop_params probe + 3 paths).         
  
  ```
  
  This exercised: non-streaming, streaming, seed=42 in generate_cfg flowing through with drop_params=True, and the function-calling code path (no crash when functions=[...] is passed). The function-calling test completed without the provider calling the function, which is expected prompt-based fncall behavior from Qwen-Agent's BaseFnCallModel (the model chose to respond in text rather than emit a <tool_call> block).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
                                        
  Example usage                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                          
  from qwen_agent.llm import get_chat_model                                                                                                                                                                                                                                                                                                                               
  from qwen_agent.llm.schema import Message                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                          
  # Claude via LiteLLM           
  cfg = {                                                                                                                                                                                                                                                                                                                                                                 
      'model': 'anthropic/claude-3-5-sonnet-20241022',
      'model_type': 'litellm',                                                                                                                                                                                                                                                                                                                                            
      'api_key': '<anthropic-key>',      
  }                                
  llm = get_chat_model(cfg)             
  for rsp in llm.chat(messages=[Message('user', 'Hi')]):                                                                                                                                                                                                                                                                                                                  
      print(rsp)                 
                                                                                                                                                                                                                                                                                                                                                                          
  # Gemini                               
  cfg = {'model': 'gemini/gemini-1.5-pro', 'model_type': 'litellm', 'api_key': '<google-key>'}                                                                                                                                                                                                                                                                            
                                        
  # Bedrock                                                                                                                                                                                                                                                                                                                                                               
  cfg = {'model': 'bedrock/anthropic.claude-3-sonnet-20240229-v1:0', 'model_type': 'litellm'}
