### PR TITLE
fix: handle assistant-first OAI conversion

### DIFF
--- a/qwen_agent/llm/base.py
+++ b/qwen_agent/llm/base.py
@@ -423,7 +423,7 @@ class BaseChatModel(ABC):
         new_messages = []
         for msg in messages:
             if msg['role'] == ASSISTANT:
-                if new_messages[-1]['role'] != ASSISTANT:
+                if not new_messages or new_messages[-1]['role'] != ASSISTANT:
                     new_messages.append({'role': ASSISTANT})
                 if msg.get('content'):
                     new_messages[-1]['content'] = msg['content']

--- a/tests/llm/test_oai.py
+++ b/tests/llm/test_oai.py
@@ -16,6 +16,7 @@ import os
 
 import pytest
 
+from qwen_agent.llm.base import BaseChatModel
 from qwen_agent.llm import get_chat_model
 from qwen_agent.llm.schema import Message
 
@@ -65,3 +66,42 @@ def test_llm_oai(functions, stream, delta_stream):
         assert response[-1].function_call.name == 'image_gen'
     else:
         assert response[-1].function_call is None
+
+
+def test_conv_qwen_agent_messages_to_oai_allows_assistant_first():
+    messages = [{'role': 'assistant', 'content': 'hello'}]
+
+    assert BaseChatModel._conv_qwen_agent_messages_to_oai(messages) == [{
+        'role': 'assistant',
+        'content': 'hello'
+    }]
+
+
+def test_conv_qwen_agent_messages_to_oai_merges_assistant_tool_call():
+    messages = [{
+        'role': 'assistant',
+        'content': 'checking'
+    }, {
+        'role': 'assistant',
+        'content': '',
+        'function_call': {
+            'name': 'search',
+            'arguments': '{"query": "qwen"}'
+        },
+        'extra': {
+            'function_id': 'call_1'
+        }
+    }]
+
+    assert BaseChatModel._conv_qwen_agent_messages_to_oai(messages) == [{
+        'role': 'assistant',
+        'content': 'checking',
+        'tool_calls': [{
+            'id': 'call_1',
+            'type': 'function',
+            'function': {
+                'name': 'search',
+                'arguments': '{"query": "qwen"}'
+            }
+        }]
+    }]


### PR DESCRIPTION
Fixes #852.

## Summary
- avoid indexing `new_messages[-1]` when the Qwen-Agent-to-OpenAI converter receives an assistant message first
- keep consecutive assistant chunks merged into one OpenAI-compatible assistant message
- add regression tests for assistant-first conversion and assistant tool-call merging

## To verify
- `python -m pytest tests/llm/test_oai.py::test_conv_qwen_agent_messages_to_oai_allows_assistant_first tests/llm/test_oai.py::test_conv_qwen_agent_messages_to_oai_merges_assistant_tool_call -q`
- `python -m py_compile qwen_agent/llm/base.py tests/llm/test_oai.py`
- `python -m ruff check qwen_agent/llm/base.py tests/llm/test_oai.py`
- `git diff --check`

I also ran `python -m flake8 qwen_agent/llm/base.py tests/llm/test_oai.py`; it reports existing line-length/trailing-whitespace findings in these files, unrelated to this two-line behavior change.
