### PR TITLE
fix: collapse redundant stop words

### DIFF
--- a/qwen_agent/utils/utils.py
+++ b/qwen_agent/utils/utils.py
@@ -484,14 +484,25 @@ def extract_images_from_messages(messages: List[Message]) -> List[str]:
     return files
 
 
+def _merge_stop_words(base_stop: List[str], new_stop: List[str]) -> List[str]:
+    stop = []
+    for word in base_stop + new_stop:
+        if word in stop:
+            continue
+        if any(word.startswith(existing) for existing in stop):
+            continue
+        stop = [existing for existing in stop if not existing.startswith(word)]
+        stop.append(word)
+    return stop
+
+
 def merge_generate_cfgs(base_generate_cfg: Optional[dict], new_generate_cfg: Optional[dict]) -> dict:
     generate_cfg: dict = copy.deepcopy(base_generate_cfg or {})
     if new_generate_cfg:
         for k, v in new_generate_cfg.items():
             if k == 'stop':
                 stop = generate_cfg.get('stop', [])
-                stop = stop + [s for s in v if s not in stop]
-                generate_cfg['stop'] = stop
+                generate_cfg['stop'] = _merge_stop_words(stop, v)
             else:
                 generate_cfg[k] = v
     return generate_cfg

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,35 @@
+from qwen_agent.utils.utils import merge_generate_cfgs
+
+
+def test_merge_generate_cfgs_drops_redundant_stop_prefixes():
+    generate_cfg = merge_generate_cfgs(
+        base_generate_cfg={
+            'stop': [
+                '✿RESULT✿',
+                '✿RETURN✿',
+                'Observation:',
+            ],
+        },
+        new_generate_cfg={
+            'stop': [
+                'Observation:\n',
+                '"], "instruction":',
+            ],
+        },
+    )
+
+    assert generate_cfg['stop'] == [
+        '✿RESULT✿',
+        '✿RETURN✿',
+        'Observation:',
+        '"], "instruction":',
+    ]
+
+
+def test_merge_generate_cfgs_keeps_shorter_stop_word():
+    generate_cfg = merge_generate_cfgs(
+        base_generate_cfg={'stop': ['Observation:\n']},
+        new_generate_cfg={'stop': ['Observation:']},
+    )
+
+    assert generate_cfg['stop'] == ['Observation:']


### PR DESCRIPTION
Fixes #370. This keeps the existing stop-word merge behavior but drops redundant longer stop words when a shorter stop string already covers them, for example Observation: covering Observation followed by a newline. It also keeps the shorter word if it is added later. Validation: python -m pytest tests/test_utils.py -q --basetemp .tmp\pytest -p no:cacheprovider; python -m py_compile qwen_agent\utils\utils.py tests\test_utils.py; python -m flake8 qwen_agent\utils\utils.py tests\test_utils.py --max-line-length=300 --extend-ignore=E231,E702,E251,W604; python -m isort --check-only --line-length 120 qwen_agent\utils\utils.py tests\test_utils.py; git diff --check.