### PR TITLE
fix: serialize messages without none fields

### DIFF
--- a/qwen_agent/llm/schema.py
+++ b/qwen_agent/llm/schema.py
@@ -14,7 +14,7 @@
 
 from typing import List, Literal, Optional, Tuple, Union
 
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, field_validator, model_serializer, model_validator
 
 DEFAULT_SYSTEM_MESSAGE = ''
 
@@ -41,6 +41,10 @@ class BaseModelCompatibleDict(BaseModel):
 
     def __setitem__(self, key, value):
         setattr(self, key, value)
+
+    @model_serializer(mode='wrap')
+    def _serialize_without_none(self, handler):
+        return {k: v for k, v in handler(self).items() if v is not None}
 
     def model_dump(self, **kwargs):
         if 'exclude_none' not in kwargs:

--- a/tests/llm/test_schema.py
+++ b/tests/llm/test_schema.py
@@ -1,0 +1,32 @@
+import pytest
+from pydantic import TypeAdapter
+
+from qwen_agent.llm.schema import ContentItem, Message
+
+
+def test_message_type_adapter_excludes_none_fields():
+    message = Message(role='assistant', content='done')
+
+    assert message.model_dump() == {'role': 'assistant', 'content': 'done'}
+    assert TypeAdapter(Message).dump_python(message) == {
+        'role': 'assistant',
+        'content': 'done',
+    }
+
+
+def test_fastapi_encoder_excludes_none_fields():
+    fastapi_encoders = pytest.importorskip('fastapi.encoders')
+
+    message = Message(role='assistant', content='done')
+
+    assert fastapi_encoders.jsonable_encoder(message) == {
+        'role': 'assistant',
+        'content': 'done',
+    }
+
+
+def test_content_item_type_and_value_still_uses_present_field():
+    item = ContentItem(text='hello')
+
+    assert item.get_type_and_value() == ('text', 'hello')
+    assert TypeAdapter(ContentItem).dump_python(item) == {'text': 'hello'}


### PR DESCRIPTION
﻿## Summary
- Make Message and related schema models omit None fields through Pydantic's serialization path.
- Cover TypeAdapter serialization, FastAPI jsonable_encoder serialization, and ContentItem's existing type/value helper.

Fixes #347.

## To verify
- python -m pytest tests/llm/test_schema.py -q
- python -m ruff check qwen_agent/llm/schema.py tests/llm/test_schema.py
- python -m py_compile qwen_agent/llm/schema.py tests/llm/test_schema.py
