### PR TITLE
fix: fallback when parallel doc qa has no files

### DIFF
--- a/qwen_agent/agents/doc_qa/parallel_doc_qa.py
+++ b/qwen_agent/agents/doc_qa/parallel_doc_qa.py
@@ -194,6 +194,10 @@ class ParallelDocQA(Assistant):
         logger.info('user_question: ' + user_question)
 
         # Implement chunk strategy for parallel agent
+        if not self._get_files(messages):
+            logger.info('No supported files found, fallback to the base Assistant workflow.')
+            return super()._run(messages=messages, lang=lang, **kwargs)
+
         records = self._parse_and_chunk_files(messages=messages)
         assert len(records) > 0, 'records is empty, all url parsing failed.'
 

--- a/tests/agents/test_parallel_qa.py
+++ b/tests/agents/test_parallel_qa.py
@@ -12,7 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
+from qwen_agent.agents.assistant import Assistant
 from qwen_agent.agents.doc_qa import ParallelDocQA
+from qwen_agent.llm.schema import Message
+
+
+class DummyLLM:
+    model = 'qwen-test'
+    model_type = ''
 
 
 def test_parallel_qa():
@@ -32,3 +41,24 @@ def test_parallel_qa():
     *_, last = agent.run(messages)
 
     assert len(last[-1]['content']) > 0
+
+
+def test_parallel_qa_without_files_falls_back_to_assistant(monkeypatch):
+    def fake_assistant_run(self, messages, lang='en', **kwargs):
+        yield [Message('assistant', 'fallback answer')]
+
+    monkeypatch.setattr(Assistant, '_run', fake_assistant_run)
+
+    agent = ParallelDocQA(llm=DummyLLM())
+    responses = list(agent._run([Message('user', '你好')], lang='zh'))
+
+    assert responses[-1][-1].content == 'fallback answer'
+
+
+def test_parallel_qa_keeps_parse_failure_assertion(monkeypatch):
+    agent = ParallelDocQA(llm=DummyLLM())
+    monkeypatch.setattr(agent, '_get_files', lambda messages: ['bad.pdf'])
+    monkeypatch.setattr(agent, '_parse_and_chunk_files', lambda messages: [])
+
+    with pytest.raises(AssertionError, match='records is empty'):
+        list(agent._run([Message('user', '总结文档')], lang='zh'))


### PR DESCRIPTION
## Summary
- make `ParallelDocQA` fall back to the base Assistant workflow when no supported document files are present
- preserve the existing assertion when files are present but parsing returns no records
- add no-network regression coverage for both paths

Fixes #251

## Tests
- .venv/bin/python -m pytest tests/agents/test_parallel_qa.py::test_parallel_qa_without_files_falls_back_to_assistant tests/agents/test_parallel_qa.py::test_parallel_qa_keeps_parse_failure_assertion -q
- .venv/bin/python -m compileall -q qwen_agent/agents/doc_qa/parallel_doc_qa.py tests/agents/test_parallel_qa.py
- git diff --check

Note: I did not run the existing `test_parallel_qa` because it requires a real DashScope/API-backed model call.