### PR TITLE
fix(tools): make whole-doc DocParser cache readable

### DIFF
--- a/qwen_agent/tools/doc_parser.py
+++ b/qwen_agent/tools/doc_parser.py
@@ -103,15 +103,23 @@ class DocParser(BaseTool):
 
         url = params['url']
 
+        # Two cache keys, one per branch of the chunking decision below:
+        #   - chunked branch: keyed by parser_page_size (it sets the chunk size)
+        #   - whole-doc branch: keyed by max_ref_token (it decides this branch),
+        #     so a later call with a smaller max_ref_token does not get served
+        #     a stale whole-doc record that should now be chunked.
         cached_name_chunking = f'{hash_sha256(url)}_{str(parser_page_size)}'
-        try:
-            # Directly load the chunked doc
-            record = self.db.get(cached_name_chunking)
-            record = json.loads(record)
-            logger.info(f'Read chunked {url} from cache.')
-            return record
-        except KeyNotExistsError:
-            doc = self.doc_extractor.call({'url': url})
+        cached_name_without_chunking = f'{hash_sha256(url)}_without_chunking_{str(max_ref_token)}'
+
+        for cached_name in (cached_name_chunking, cached_name_without_chunking):
+            try:
+                record = self.db.get(cached_name)
+                record = json.loads(record)
+                logger.info(f'Read parsed {url} from cache.')
+                return record
+            except KeyNotExistsError:
+                continue
+        doc = self.doc_extractor.call({'url': url})
 
         total_token = 0
         for page in doc:
@@ -136,9 +144,10 @@ class DocParser(BaseTool):
                       },
                       token=total_token)
             ]
-            cached_name_chunking = f'{hash_sha256(url)}_without_chunking'
+            cached_name = cached_name_without_chunking
         else:
             content = self.split_doc_to_chunk(doc, url, title=title, parser_page_size=parser_page_size)
+            cached_name = cached_name_chunking
 
         time2 = time.time()
         logger.info(f'Finished chunking {url} ({title}). Time spent: {time2 - time1} seconds.')
@@ -146,7 +155,7 @@ class DocParser(BaseTool):
         # save the document data
         new_record = Record(url=url, raw=content, title=title).to_dict()
         new_record_str = json.dumps(new_record, ensure_ascii=False)
-        self.db.put(cached_name_chunking, new_record_str)
+        self.db.put(cached_name, new_record_str)
         return new_record
 
     def split_doc_to_chunk(self,

--- a/tests/tools/test_doc_parser.py
+++ b/tests/tools/test_doc_parser.py
@@ -1,16 +1,19 @@
 # Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import os
+import tempfile
 
 from qwen_agent.tools import DocParser
 
@@ -21,5 +24,63 @@ def test_doc_parser():
     print(res)
 
 
+def _write_small_doc(directory: str) -> str:
+    path = os.path.join(directory, 'small.txt')
+    with open(path, 'w') as f:
+        f.write('Qwen-Agent is a framework for developing LLM applications.\n' * 5)
+    return path
+
+
+def _count_extractor_calls(tool: DocParser) -> dict:
+    counter = {'n': 0}
+    original = tool.doc_extractor.call
+
+    def wrapped(*args, **kwargs):
+        counter['n'] += 1
+        return original(*args, **kwargs)
+
+    tool.doc_extractor.call = wrapped
+    return counter
+
+
+def test_doc_parser_cache_hit_for_small_doc():
+    """A document small enough to skip chunking must still be served from the
+    DocParser-level cache on a second call (it used to be written under a key
+    that the read path never checked)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        doc_path = _write_small_doc(tmp)
+        tool = DocParser({'path': os.path.join(tmp, 'doc_parser_cache')})
+        counter = _count_extractor_calls(tool)
+
+        first = tool.call({'url': doc_path})
+        second = tool.call({'url': doc_path})
+
+        # The whole-doc record is small, so the second call must hit the cache
+        # instead of re-running document extraction.
+        extractions = counter['n']
+        assert extractions == 1, f'expected 1 extraction, got {extractions}'
+        assert first == second
+
+
+def test_doc_parser_cache_not_stale_on_max_ref_token_change():
+    """The whole-doc cache is keyed by max_ref_token, the value that decides
+    the un-chunked branch. Lowering max_ref_token must not serve a stale
+    whole-doc record that should now be chunked."""
+    with tempfile.TemporaryDirectory() as tmp:
+        doc_path = _write_small_doc(tmp)
+        tool = DocParser({'path': os.path.join(tmp, 'doc_parser_cache')})
+        counter = _count_extractor_calls(tool)
+
+        # Large max_ref_token -> whole-doc branch, cached.
+        tool.call({'url': doc_path}, max_ref_token=20000)
+        assert counter['n'] == 1
+
+        # A much smaller max_ref_token must not reuse the whole-doc record.
+        tool.call({'url': doc_path}, max_ref_token=1)
+        assert counter['n'] == 2, 'stale whole-doc record served after max_ref_token changed'
+
+
 if __name__ == '__main__':
     test_doc_parser()
+    test_doc_parser_cache_hit_for_small_doc()
+    test_doc_parser_cache_not_stale_on_max_ref_token_change()


### PR DESCRIPTION
## Summary

`DocParser.call()` writes its result cache, but for any document small
enough to skip chunking the record lands under a key the read path
never checks — so the `DocParser`-level cache is effectively dead for
every un-chunked document.

The read at the top of `call()` looks up `<hash>_<parser_page_size>`:

```python
cached_name_chunking = f'{hash_sha256(url)}_{str(parser_page_size)}'
record = self.db.get(cached_name_chunking)   # only ever this key
```

But when `total_token <= max_ref_token` (the whole-doc branch) the key
is reassigned before the write:

```python
cached_name_chunking = f'{hash_sha256(url)}_without_chunking'
...
self.db.put(cached_name_chunking, new_record_str)   # writes a key nobody reads
```

`Storage.get()` does exact-path lookup with no prefix/fallback, so
`<hash>_without_chunking` is written on every call and read on none.
With the default `max_ref_token` of 20000, that is the common case:
each repeat `call()` for the same document redundantly re-runs token
counting and whole-doc assembly. (The heavier extraction is still
served by `SimpleDocParser`'s own `_ori` cache, so this is wasted
post-processing rather than a full re-parse.)

## Fix

- Make the read path try the whole-doc key in addition to the chunked
  key, so a previously parsed un-chunked document is served from cache.
- Key the whole-doc cache by `max_ref_token` (`_without_chunking_<n>`)
  — `max_ref_token` is the value that *decides* the un-chunked branch,
  so a later call with a smaller `max_ref_token` correctly misses and
  re-parses instead of being served a stale whole-doc record that
  should now be chunked.
- The chunked-branch key is unchanged.

## Tests

`tests/tools/test_doc_parser.py` gains two offline, deterministic tests
(temp dir + local `.txt`, no network):

- `test_doc_parser_cache_hit_for_small_doc` — parses a small document
  twice and asserts document extraction runs only once. This **fails on
  `main`** (extraction runs twice) and passes with the fix.
- `test_doc_parser_cache_not_stale_on_max_ref_token_change` — guards
  the `max_ref_token` key suffix: it fails against a naive fix that
  makes the whole-doc key readable but omits the suffix (verified), so
  it locks in the staleness guarantee even though it also passes on
  `main` (where the cache is simply dead).

## Compatibility

The chunked cache key is untouched. Pre-existing on-disk
`<hash>_without_chunking` entries (suffix-less) are left orphaned —
harmless, because they were already unreadable on `main` due to this
very bug; at worst a document is re-processed once.

## Test plan

- [x] `pytest tests/tools/test_doc_parser.py -k cache` passes on the branch
- [x] `test_doc_parser_cache_hit_for_small_doc` fails on `main`, passes with the fix
- [x] `pre-commit run` (flake8 / isort / yapf / hooks) passes on both changed files
