### PR TITLE
fix: preserve streamed empty tool arguments

### DIFF
--- a/qwen_agent/llm/fncall_prompts/nous_fncall_prompt.py
+++ b/qwen_agent/llm/fncall_prompts/nous_fncall_prompt.py
@@ -99,7 +99,7 @@ class NousFnCallPrompt(BaseFnCallPrompt):
         else:
             messages = [Message(role=SYSTEM, content=[ContentItem(text=tool_system)])] + messages
         return messages
-    
+
     def postprocess_fncall_messages(
         self,
         messages: List[Message],
@@ -311,9 +311,37 @@ def extract_fn(text: str):
             fn_name = _text[:j]
     if k > 0:
         fn_args = text[k + len(fn_args_s):]
-    fn_args = fn_args.strip()
-    if len(fn_args) > 2:
-        fn_args = fn_args[:-1]
-    else:
-        fn_args = ''
+    fn_args = _extract_json_value_prefix(fn_args)
     return fn_name, fn_args
+
+
+def _extract_json_value_prefix(text: str) -> str:
+    text = text.strip()
+    if not text:
+        return ''
+    if text[0] not in '{[':
+        return text
+
+    closers = {'{': '}', '[': ']'}
+    stack = []
+    in_string = False
+    escaped = False
+    for i, ch in enumerate(text):
+        if escaped:
+            escaped = False
+            continue
+        if ch == '\\' and in_string:
+            escaped = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch in closers:
+            stack.append(closers[ch])
+        elif stack and ch == stack[-1]:
+            stack.pop()
+            if not stack:
+                return text[:i + 1]
+    return text

--- a/tests/llm/test_nous_fncall_prompt.py
+++ b/tests/llm/test_nous_fncall_prompt.py
@@ -1,0 +1,32 @@
+from qwen_agent.llm.fncall_prompts.nous_fncall_prompt import NousFnCallPrompt, extract_fn
+from qwen_agent.llm.schema import ASSISTANT, ContentItem, Message
+
+
+def test_extract_fn_keeps_empty_arguments_object():
+    name, arguments = extract_fn('{"name": "search", "arguments": {}}\n')
+
+    assert name == 'search'
+    assert arguments == '{}'
+
+
+def test_extract_fn_stops_after_nested_arguments_object():
+    name, arguments = extract_fn('{"name": "search", "arguments": {"query": {"q": "qwen"}}}\n')
+
+    assert name == 'search'
+    assert arguments == '{"query": {"q": "qwen"}}'
+
+
+def test_postprocess_incomplete_tool_call_keeps_empty_arguments():
+    messages = [
+        Message(
+            role=ASSISTANT,
+            content=[
+                ContentItem(text='<tool_call>\n{"name": "search", "arguments": {}}\n'),
+            ],
+        ),
+    ]
+
+    parsed = NousFnCallPrompt().postprocess_fncall_messages(messages)
+
+    assert parsed[-1].function_call.name == 'search'
+    assert parsed[-1].function_call.arguments == '{}'


### PR DESCRIPTION
﻿## Summary
- parse the first complete JSON value for streamed Nous tool-call arguments
- preserve `{}` instead of dropping empty argument objects
- add direct and postprocess regression tests for incomplete streamed tool calls

Fixes #734.

## To verify
- python -m py_compile qwen_agent\llm\fncall_prompts\nous_fncall_prompt.py tests\llm\test_nous_fncall_prompt.py
- python -m pytest tests\llm\test_nous_fncall_prompt.py -q
- python -m flake8 --max-line-length=300 --extend-ignore=E231,E702,E251,W604 qwen_agent\llm\fncall_prompts\nous_fncall_prompt.py tests\llm\test_nous_fncall_prompt.py
- python -m isort --check-only --line-length 120 qwen_agent\llm\fncall_prompts\nous_fncall_prompt.py tests\llm\test_nous_fncall_prompt.py
- git diff --check
