### PR TITLE
fix: correct misnamed dotenv dependency to python-dotenv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'requests',
         'tiktoken',
         'pillow',
-        'dotenv',
+        'python-dotenv',
     ],
     extras_require={
         # Extra dependencies for RAG:


### PR DESCRIPTION
## Summary

- Fixes the misnamed `dotenv` dependency in `setup.py` by replacing it with `python-dotenv`
- The `dotenv` package on PyPI is a different package that does not provide the `dotenv` module, causing a `ModuleNotFoundError` on fresh installs
- The `qwen_agent/tools/mcp_manager.py` imports `from dotenv import load_dotenv`, which is provided by `python-dotenv`, not the `dotenv` package

Fixes #837

## Test Plan

- [ ] `pip install -e .` succeeds and `python -c "import qwen_agent"` works without ModuleNotFoundError