### PR TITLE
fix(python_executor): strengthen security filter to block common bypasses

### DIFF
--- a/qwen_agent/agent.py
+++ b/qwen_agent/agent.py
@@ -41,6 +41,7 @@ class Agent(ABC):
                  system_message: Optional[str] = DEFAULT_SYSTEM_MESSAGE,
                  name: Optional[str] = None,
                  description: Optional[str] = None,
+                 system_prompt_files: Optional[List[str]] = None,
                  **kwargs):
         """Initialization the agent.
 
@@ -52,6 +53,7 @@ class Agent(ABC):
             system_message: The specified system message for LLM chat.
             name: The name of this agent.
             description: The description of this agent, which will be used for multi_agent.
+            system_prompt_files: A list of file paths to load and prepend to the system message.
         """
         if isinstance(llm, dict):
             self.llm = get_chat_model(llm)
@@ -63,6 +65,24 @@ class Agent(ABC):
         if function_list:
             for tool in function_list:
                 self._init_tool(tool)
+
+        # Load system prompt files if provided
+        if system_prompt_files:
+            loaded_content = []
+            for file_path in system_prompt_files:
+                try:
+                    with open(file_path, 'r', encoding='utf-8') as f:
+                        loaded_content.append(f.read())
+                except FileNotFoundError:
+                    logger.warning(f'System prompt file not found: {file_path}')
+                except Exception as e:
+                    logger.warning(f'Error reading system prompt file {file_path}: {e}')
+            if loaded_content:
+                file_prompt = '\n\n'.join(loaded_content)
+                if system_message:
+                    system_message = file_prompt + '\n\n' + system_message
+                else:
+                    system_message = file_prompt
 
         self.system_message = system_message
         self.name = name

--- a/qwen_agent/agent.py
+++ b/qwen_agent/agent.py
@@ -41,7 +41,6 @@ class Agent(ABC):
                  system_message: Optional[str] = DEFAULT_SYSTEM_MESSAGE,
                  name: Optional[str] = None,
                  description: Optional[str] = None,
-                 system_prompt_files: Optional[List[str]] = None,
                  **kwargs):
         """Initialization the agent.
 
@@ -53,7 +52,6 @@ class Agent(ABC):
             system_message: The specified system message for LLM chat.
             name: The name of this agent.
             description: The description of this agent, which will be used for multi_agent.
-            system_prompt_files: A list of file paths to load and prepend to the system message.
         """
         if isinstance(llm, dict):
             self.llm = get_chat_model(llm)
@@ -65,24 +63,6 @@ class Agent(ABC):
         if function_list:
             for tool in function_list:
                 self._init_tool(tool)
-
-        # Load system prompt files if provided
-        if system_prompt_files:
-            loaded_content = []
-            for file_path in system_prompt_files:
-                try:
-                    with open(file_path, 'r', encoding='utf-8') as f:
-                        loaded_content.append(f.read())
-                except FileNotFoundError:
-                    logger.warning(f'System prompt file not found: {file_path}')
-                except Exception as e:
-                    logger.warning(f'Error reading system prompt file {file_path}: {e}')
-            if loaded_content:
-                file_prompt = '\n\n'.join(loaded_content)
-                if system_message:
-                    system_message = file_prompt + '\n\n' + system_message
-                else:
-                    system_message = file_prompt
 
         self.system_message = system_message
         self.name = name

--- a/qwen_agent/tools/python_executor.py
+++ b/qwen_agent/tools/python_executor.py
@@ -44,8 +44,22 @@ class GenericRuntime:
             self.exec_code(c)
 
     def exec_code(self, code_piece: str) -> None:
-        if regex.search(r'(\s|^)?input\(', code_piece) or regex.search(r'(\s|^)?os.system\(', code_piece):
-            raise RuntimeError()
+        # Block dangerous imports and functions that could compromise security
+        dangerous_patterns = [
+            r'(\s|^)?input\(',
+            r'(\s|^)?os\.system\(',
+            r'(\s|^)?os\.popen\(',
+            r'(\s|^)?subprocess\.',
+            r'(\s|^)?__import__\(',
+            r'(\s|^)?open\(',
+            r'(\s|^)?eval\(',
+            r'(\s|^)?exec\(',
+            r'(\s|^)?compile\(',
+            r'getattr\s*\(\s*__import__',
+        ]
+        for pattern in dangerous_patterns:
+            if regex.search(pattern, code_piece):
+                raise RuntimeError(f'Blocked dangerous operation: {pattern}')
         exec(code_piece, self._global_vars)
 
     def eval_code(self, expr: str) -> Any:


### PR DESCRIPTION
Fixes #866

Expand the regex-based filter in GenericRuntime.exec_code from 2 patterns to 10, blocking __import__, subprocess, os.popen, open, eval, exec, compile, and getattr+__import__ bypasses.