### PR TITLE
fix: lazy-load optional dependencies during import

### DIFF
--- a/qwen_agent/tools/python_executor.py
+++ b/qwen_agent/tools/python_executor.py
@@ -61,12 +61,21 @@ class GenericRuntime:
 
 
 class DateRuntime(GenericRuntime):
-    import dateutil.relativedelta
-    GLOBAL_DICT = {
-        'datetime': datetime.datetime,
-        'timedelta': dateutil.relativedelta.relativedelta,
-        'relativedelta': dateutil.relativedelta.relativedelta
-    }
+
+    def __init__(self):
+        try:
+            import dateutil.relativedelta
+        except ImportError as e:
+            raise ImportError(
+                'The dependencies for Python Executor support are not installed. '
+                'Please install the required dependencies by running: pip install "qwen-agent[python_executor]"') from e
+
+        self.GLOBAL_DICT = {
+            'datetime': datetime.datetime,
+            'timedelta': dateutil.relativedelta.relativedelta,
+            'relativedelta': dateutil.relativedelta.relativedelta
+        }
+        super().__init__()
 
 
 class CustomDict(dict):

--- a/qwen_agent/utils/utils.py
+++ b/qwen_agent/utils/utils.py
@@ -29,9 +29,7 @@ from io import BytesIO
 from typing import Any, List, Literal, Optional, Tuple, Union
 
 import json5
-import numpy as np
 import requests
-import soundfile as sf
 from pydantic import BaseModel
 
 from qwen_agent.llm.schema import ASSISTANT, DEFAULT_SYSTEM_MESSAGE, FUNCTION, SYSTEM, USER, ContentItem, Message
@@ -443,6 +441,12 @@ def format_as_text_message(
 
 
 def save_audio_to_file(base_64: str, file_name: str):
+    try:
+        import numpy as np
+        import soundfile as sf
+    except ImportError as e:
+        raise ImportError('Saving audio content requires numpy and soundfile to be installed.') from e
+
     wav_bytes = base64.b64decode(base_64)
     audio_np = np.frombuffer(wav_bytes, dtype=np.int16)
     sf.write(file_name, audio_np, samplerate=24000)

--- a/tests/tools/test_optional_dependency_imports.py
+++ b/tests/tools/test_optional_dependency_imports.py
@@ -1,0 +1,46 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import builtins
+
+import pytest
+
+from qwen_agent.tools.python_executor import DateRuntime
+from qwen_agent.utils.utils import save_audio_to_file
+
+
+def _block_imports(monkeypatch, *blocked_modules):
+    original_import = builtins.__import__
+
+    def import_without_optional_dep(name, globals=None, locals=None, fromlist=(), level=0):
+        if any(name == module or name.startswith(f'{module}.') for module in blocked_modules):
+            raise ImportError(f'No module named {name}')
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, '__import__', import_without_optional_dep)
+
+
+def test_date_runtime_reports_python_executor_extra_when_dateutil_missing(monkeypatch):
+    _block_imports(monkeypatch, 'dateutil')
+
+    with pytest.raises(ImportError, match=r'qwen-agent\[python_executor\]'):
+        DateRuntime()
+
+
+@pytest.mark.parametrize('missing_module', ['numpy', 'soundfile'])
+def test_save_audio_to_file_reports_audio_dependencies_when_optional_dep_missing(monkeypatch, tmp_path, missing_module):
+    _block_imports(monkeypatch, missing_module)
+
+    with pytest.raises(ImportError, match='Saving audio content requires numpy and soundfile'):
+        save_audio_to_file('', str(tmp_path / 'audio.wav'))


### PR DESCRIPTION
## Summary
- move `dateutil` import for `DateRuntime` out of the class body so importing `qwen_agent.agents.Assistant` does not require the `python_executor` extra
- lazy-load `numpy` and `soundfile` only when saving generated audio
- add regression tests for missing optional dependencies

Fixes #545.

## Tests
- `uv run pytest tests/tools/test_optional_dependency_imports.py -q`
- `uvx --python 3.12 pre-commit run --files qwen_agent/tools/python_executor.py qwen_agent/utils/utils.py tests/tools/test_optional_dependency_imports.py`
- `git diff --check`
- clean venv: `uv venv /tmp/qwen-agent-min-venv && VIRTUAL_ENV=/tmp/qwen-agent-min-venv uv pip install -e . && python -c "import qwen_agent; from qwen_agent.agents import Assistant"`