### PR TITLE
fix: limit OAI stop words in requests

### DIFF
--- a/qwen_agent/llm/oai.py
+++ b/qwen_agent/llm/oai.py
@@ -33,6 +33,9 @@ from qwen_agent.llm.schema import ASSISTANT, FunctionCall, Message
 from qwen_agent.log import logger
 
 
+OAI_MAX_STOP_WORDS = 4
+
+
 @register_llm('oai')
 class TextChatAtOAI(BaseFnCallModel):
 
@@ -102,9 +105,11 @@ class TextChatAtOAI(BaseFnCallModel):
         generate_cfg: dict,
     ) -> Iterator[List[Message]]:
         messages = self.convert_messages_to_dicts(messages)
+        request_generate_cfg = self._format_generate_cfg_for_oai(generate_cfg)
         logger.debug(f'LLM Input generate_cfg: \n{generate_cfg}')
         try:
-            response = self._chat_complete_create(model=self.model, messages=messages, stream=True, **generate_cfg)
+            response = self._chat_complete_create(
+                model=self.model, messages=messages, stream=True, **request_generate_cfg)
             if delta_stream:
                 for chunk in response:
                     if chunk.choices:
@@ -164,8 +169,10 @@ class TextChatAtOAI(BaseFnCallModel):
         generate_cfg: dict,
     ) -> List[Message]:
         messages = self.convert_messages_to_dicts(messages)
+        request_generate_cfg = self._format_generate_cfg_for_oai(generate_cfg)
         try:
-            response = self._chat_complete_create(model=self.model, messages=messages, stream=False, **generate_cfg)
+            response = self._chat_complete_create(
+                model=self.model, messages=messages, stream=False, **request_generate_cfg)
             if hasattr(response.choices[0].message, 'reasoning_content'):
                 return [
                     Message(role=ASSISTANT,
@@ -176,6 +183,13 @@ class TextChatAtOAI(BaseFnCallModel):
                 return [Message(role=ASSISTANT, content=response.choices[0].message.content)]
         except OpenAIError as ex:
             raise ModelServiceError(exception=ex)
+
+    def _format_generate_cfg_for_oai(self, generate_cfg: dict) -> dict:
+        generate_cfg = copy.deepcopy(generate_cfg)
+        stop = generate_cfg.get('stop')
+        if isinstance(stop, list) and len(stop) > OAI_MAX_STOP_WORDS:
+            generate_cfg['stop'] = stop[:OAI_MAX_STOP_WORDS]
+        return generate_cfg
 
     def convert_messages_to_dicts(self, messages: List[Message]) -> List[dict]:
         # TODO: Change when the VLLM deployed model needs to pass reasoning_complete.

--- a/tests/llm/test_oai.py
+++ b/tests/llm/test_oai.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 import os
+from types import SimpleNamespace
 
 import pytest
 
 from qwen_agent.llm import get_chat_model
+from qwen_agent.llm.oai import TextChatAtOAI
 from qwen_agent.llm.schema import Message
 
 functions = [{
@@ -33,6 +35,56 @@ functions = [{
         'required': ['prompt'],
     }
 }]
+
+
+def test_oai_stop_words_are_limited_for_api_request():
+    llm = TextChatAtOAI({'model': 'qwen2-7b-instruct', 'api_key': 'EMPTY'})
+    captured_kwargs = {}
+
+    def fake_chat_complete_create(**kwargs):
+        captured_kwargs.update(kwargs)
+        message = SimpleNamespace(content='ok e trailing')
+        choice = SimpleNamespace(message=message)
+        return SimpleNamespace(choices=[choice])
+
+    llm._chat_complete_create = fake_chat_complete_create
+    generate_cfg = {'stop': ['a', 'b', 'c', 'd', 'e']}
+
+    response = llm.chat(
+        [Message('user', 'hello')],
+        stream=False,
+        extra_generate_cfg=generate_cfg,
+    )
+
+    assert captured_kwargs['stop'] == ['a', 'b', 'c', 'd']
+    assert response[0].content == 'ok '
+    assert generate_cfg['stop'] == ['a', 'b', 'c', 'd', 'e']
+
+
+def test_oai_stream_stop_words_are_limited_for_api_request():
+    llm = TextChatAtOAI({'model': 'qwen2-7b-instruct', 'api_key': 'EMPTY'})
+    captured_kwargs = {}
+
+    def fake_chat_complete_create(**kwargs):
+        captured_kwargs.update(kwargs)
+        delta = SimpleNamespace(content='ok e trailing')
+        choice = SimpleNamespace(delta=delta)
+        return [SimpleNamespace(choices=[choice])]
+
+    llm._chat_complete_create = fake_chat_complete_create
+    generate_cfg = {'stop': ['a', 'b', 'c', 'd', 'e']}
+
+    response = list(
+        llm.chat(
+            [Message('user', 'hello')],
+            stream=True,
+            extra_generate_cfg=generate_cfg,
+        )
+    )[-1]
+
+    assert captured_kwargs['stop'] == ['a', 'b', 'c', 'd']
+    assert response[0].content == 'ok '
+    assert generate_cfg['stop'] == ['a', 'b', 'c', 'd', 'e']
 
 
 @pytest.mark.parametrize('functions', [None, functions])


### PR DESCRIPTION
## Summary

Fixes #370.

When multiple agent layers merge `generate_cfg["stop"]`, the OAI backend can forward more than four stop words to OpenAI-compatible APIs. Those APIs reject the request before Qwen-Agent can do its own stop-word postprocessing.

This change limits only the stop list sent to the OAI API request to the first four entries. The original `generate_cfg` remains unchanged, so Qwen-Agent can still use the full stop list for local response postprocessing.

Both non-streaming and streaming OAI chat paths use the trimmed request copy.

## Validation

- Baseline reproduction on `origin/main`: a fake OAI chat call received all 5 stop strings: `['a', 'b', 'c', 'd', 'e']`.
- Patched branch: the fake OAI chat call receives `['a', 'b', 'c', 'd']`, while the returned text is still locally truncated by the fifth stop string.
- `PYTHONPATH=. uv run --with-editable . --with pytest --with numpy --with soundfile --with python-dateutil pytest tests/llm/test_oai.py::test_oai_stop_words_are_limited_for_api_request tests/llm/test_oai.py::test_oai_stream_stop_words_are_limited_for_api_request -q`
- `PYTHONPATH=. uv run --with ruff ruff check qwen_agent/llm/oai.py tests/llm/test_oai.py`
