### PR TITLE
Support for reasoning field in OpenAI adapter.

### DIFF
--- a/qwen_agent/llm/oai.py
+++ b/qwen_agent/llm/oai.py
@@ -108,12 +108,15 @@ class TextChatAtOAI(BaseFnCallModel):
             if delta_stream:
                 for chunk in response:
                     if chunk.choices:
-                        if hasattr(chunk.choices[0].delta,
-                                   'reasoning_content') and chunk.choices[0].delta.reasoning_content:
+                        reasoning_content = (
+                            getattr(chunk.choices[0].delta, 'reasoning_content', None) 
+                            or getattr(chunk.choices[0].delta, 'reasoning', None)
+                        )
+                        if reasoning_content:
                             yield [
                                 Message(role=ASSISTANT,
                                         content='',
-                                        reasoning_content=chunk.choices[0].delta.reasoning_content)
+                                        reasoning_content=reasoning_content)
                             ]
                         if hasattr(chunk.choices[0].delta, 'content') and chunk.choices[0].delta.content:
                             yield [Message(role=ASSISTANT, content=chunk.choices[0].delta.content)]
@@ -123,9 +126,12 @@ class TextChatAtOAI(BaseFnCallModel):
                 full_tool_calls = []
                 for chunk in response:
                     if chunk.choices:
-                        if hasattr(chunk.choices[0].delta,
-                                   'reasoning_content') and chunk.choices[0].delta.reasoning_content:
-                            full_reasoning_content += chunk.choices[0].delta.reasoning_content
+                        reasoning_content = (
+                            getattr(chunk.choices[0].delta, 'reasoning_content', None)
+                            or getattr(chunk.choices[0].delta, 'reasoning', None)
+                        )
+                        if reasoning_content:
+                            full_reasoning_content += reasoning_content
                         if hasattr(chunk.choices[0].delta, 'content') and chunk.choices[0].delta.content:
                             full_response += chunk.choices[0].delta.content
                         if hasattr(chunk.choices[0].delta, 'tool_calls') and chunk.choices[0].delta.tool_calls:
@@ -166,11 +172,12 @@ class TextChatAtOAI(BaseFnCallModel):
         messages = self.convert_messages_to_dicts(messages)
         try:
             response = self._chat_complete_create(model=self.model, messages=messages, stream=False, **generate_cfg)
-            if hasattr(response.choices[0].message, 'reasoning_content'):
+            if hasattr(response.choices[0].message, 'reasoning_content') or hasattr(response.choices[0].message, 'reasoning'):
                 return [
                     Message(role=ASSISTANT,
                             content=response.choices[0].message.content,
-                            reasoning_content=response.choices[0].message.reasoning_content)
+                            reasoning_content=(getattr(response.choices[0].message, 'reasoning_content', None)
+                                or getattr(response.choices[0].message, 'reasoning', None)))
                 ]
             else:
                 return [Message(role=ASSISTANT, content=response.choices[0].message.content)]


### PR DESCRIPTION
The latest vLLM version (~v0.22) uses `reasoning` rather than `reasoning_content` as a field alongside `role` and `content`.

I updated `qwen_agent/llm/oai.py` such that it verifies both the `reasoning` and `reasoning_content` field.

Without this fix, the `reasoning` field gets discarded and only `role` and `content` get returned.