### PR TITLE
Fix is_image() matching extension substrings without a separator

### DIFF
--- a/qwen_agent/utils/utils.py
+++ b/qwen_agent/utils/utils.py
@@ -136,7 +136,7 @@ def is_http_url(path_or_url: str) -> bool:
 def is_image(path_or_url: str) -> bool:
     filename = get_basename_from_url(path_or_url).lower()
     for ext in ['jpg', 'jpeg', 'png', 'webp']:
-        if filename.endswith(ext):
+        if filename.endswith('.' + ext):
             return True
     return False
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,0 +1,44 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from qwen_agent.utils.utils import is_image
+
+
+def test_is_image_recognizes_real_extensions():
+    assert is_image('photo.jpg')
+    assert is_image('photo.jpeg')
+    assert is_image('photo.png')
+    assert is_image('photo.webp')
+    # Case-insensitive and works for URLs.
+    assert is_image('https://example.com/dir/IMG.PNG?token=abc')
+
+
+def test_is_image_rejects_non_images():
+    assert not is_image('document.pdf')
+    assert not is_image('archive.zip')
+
+
+def test_is_image_requires_extension_separator():
+    # A trailing extension substring without a "." separator must not count as
+    # an image, e.g. a path component literally named "png" or a file whose
+    # name merely ends with the extension letters.
+    assert not is_image('https://example.com/png')
+    assert not is_image('backup_jpg')
+    assert not is_image('mockpng')
+
+
+if __name__ == '__main__':
+    test_is_image_recognizes_real_extensions()
+    test_is_image_rejects_non_images()
+    test_is_image_requires_extension_separator()


### PR DESCRIPTION
### Bug

`is_image()` checks the file extension with `filename.endswith(ext)` for `ext` in `['jpg', 'jpeg', 'png', 'webp']`, omitting the `.` separator. As a result any name that merely *ends with* those letters is treated as an image:

```python
>>> from qwen_agent.utils.utils import is_image
>>> is_image('https://example.com/png')   # path component literally "png"
True
>>> is_image('backup_jpg')                 # no extension at all
True
>>> is_image('mockpng')
True
```

None of these are images, so callers that branch on `is_image()` mishandle them.

### Fix

Match against the extension *including* its separator (`filename.endswith('.' + ext)`). This only removes the false positives above; legitimate names such as `photo.png`, `IMG.PNG`, and URLs with query strings (`.../IMG.PNG?token=abc`) still return `True`.

### Verification

Added `tests/utils/test_utils.py` covering valid extensions, case-insensitive URLs with query strings, non-images, and the separator-less false positives.

```
$ python -m pytest tests/utils/test_utils.py -v
...
tests/utils/test_utils.py::test_is_image_recognizes_real_extensions PASSED
tests/utils/test_utils.py::test_is_image_rejects_non_images PASSED
tests/utils/test_utils.py::test_is_image_requires_extension_separator PASSED
3 passed
```

The new test fails on `main` (`is_image('https://example.com/png')` returns `True`) and passes with this change.