### PR TITLE
docs: clarify that Reply: in ROUTER_PROMPT serves as a stop anchor, not router output

### DIFF
--- a/qwen_agent/agents/router.py
+++ b/qwen_agent/agents/router.py
@@ -22,6 +22,7 @@ from qwen_agent.llm.schema import ASSISTANT, ROLE, SYSTEM, Message
 from qwen_agent.log import logger
 from qwen_agent.tools import BaseTool
 from qwen_agent.utils.utils import merge_generate_cfgs
+
 # Design note: The template contains two lines for the routing format:
 #   Call: <agent_name>  – the router outputs this to select a sub-agent
 #   Reply: ...          – this line is a stop anchor only; LLM generation halts
@@ -61,8 +62,8 @@ class Router(Assistant, MultiAgentHub):
                          description=description,
                          files=files,
                          rag_cfg=rag_cfg)
-# Stop generation at 'Reply:' so the router only outputs 'Call: <name>'.
-# The sub-agent produces the actual reply; see ROUTER_PROMPT design note above.
+        # Stop generation at 'Reply:' so the router only outputs 'Call: <name>'.
+        # The sub-agent produces the actual reply; see ROUTER_PROMPT design note above.
         self.extra_generate_cfg = merge_generate_cfgs(
             base_generate_cfg=self.extra_generate_cfg,
             new_generate_cfg={'stop': ['Reply:', 'Reply:\n']},

--- a/qwen_agent/agents/router.py
+++ b/qwen_agent/agents/router.py
@@ -22,7 +22,15 @@ from qwen_agent.llm.schema import ASSISTANT, ROLE, SYSTEM, Message
 from qwen_agent.log import logger
 from qwen_agent.tools import BaseTool
 from qwen_agent.utils.utils import merge_generate_cfgs
-
+# Design note: The template contains two lines for the routing format:
+#   Call: <agent_name>  – the router outputs this to select a sub-agent
+#   Reply: ...          – this line is a stop anchor only; LLM generation halts
+#                         at 'Reply:' via the stop sequence in __init__.
+#                         The actual reply is produced by the selected sub-agent.
+#                         The line is retained in the template so the LLM
+#                         understands the full expected exchange structure, and
+#                         it matches the format injected by supplement_name_special_token
+#                         into the message history.
 ROUTER_PROMPT = '''你有下列帮手：
 {agent_descs}
 
@@ -53,6 +61,8 @@ class Router(Assistant, MultiAgentHub):
                          description=description,
                          files=files,
                          rag_cfg=rag_cfg)
+# Stop generation at 'Reply:' so the router only outputs 'Call: <name>'.
+# The sub-agent produces the actual reply; see ROUTER_PROMPT design note above.
         self.extra_generate_cfg = merge_generate_cfgs(
             base_generate_cfg=self.extra_generate_cfg,
             new_generate_cfg={'stop': ['Reply:', 'Reply:\n']},


### PR DESCRIPTION
## Summary

Add clarifying comments in `router.py` to explain the design intent of the
`Reply:` line in `ROUTER_PROMPT`.

## Motivation

As raised in #892, the `Reply: ...` line in `ROUTER_PROMPT` is misleading:
it appears to instruct the router to generate the sub-agent's reply itself,
but in practice LLM generation is halted at `Reply:` via the `stop` sequence
configured in `__init__`. The actual reply is produced by the selected
sub-agent, not the router.

## Changes

- Added a design note comment above `ROUTER_PROMPT` explaining:
  - `Call: <name>` is the router's actual output
  - `Reply:` acts only as a stop anchor
  - The line is retained so the LLM understands the full exchange format,
    consistent with `supplement_name_special_token`
- Added a cross-reference comment at the `stop` configuration site in
  `__init__`

## Tests

This is a comment-only change with no logic modifications. No functional
behavior is affected.

## Notes

No breaking changes. No new dependencies.

Closes #892