### PR TITLE
fix(gui): keep WebUI chat input visible

### DIFF
--- a/qwen_agent/gui/assets/appBot.css
+++ b/qwen_agent/gui/assets/appBot.css
@@ -108,6 +108,12 @@
 
 .container {
   /* flex-direction: row-reverse; */
+  height: calc(100vh - 32px);
+  overflow: hidden;
+}
+
+.chat-column {
+  min-height: 0;
 }
 
 .markdown-body .message {

--- a/qwen_agent/gui/web_ui.py
+++ b/qwen_agent/gui/web_ui.py
@@ -104,13 +104,13 @@ class WebUI:
             history = gr.State([])
             with ms.Application():
                 with gr.Row(elem_classes='container'):
-                    with gr.Column(scale=4):
+                    with gr.Column(scale=4, elem_classes='chat-column'):
                         chatbot = mgr.Chatbot(value=convert_history_to_chatbot(messages=messages),
                                               avatar_images=[
                                                   self.user_config,
                                                   self.agent_config_list,
                                               ],
-                                              height=850,
+                                              height='clamp(360px, calc(100vh - 220px), 850px)',
                                               avatar_image_width=80,
                                               flushing=False,
                                               show_copy_button=True,


### PR DESCRIPTION
## What this PR does

This PR adjusts the WebUI layout so the conversation area scrolls independently while the message input stays visible in the viewport. It replaces the fixed chatbot height with a viewport-aware layout and adds a small CSS constraint to keep the chat column from stretching the whole page.

## Why it's needed

The previous layout used a fixed chatbot height, which could make the page taller than the viewport on typical browser windows. In that case, the message input would be pushed out of view and users had to scroll the whole page before sending a message. This PR keeps the input area reachable and makes the chat experience smoother.

## Reviewer Test Plan

### How to verify

Open the WebUI with a long initial conversation and confirm that the message input, upload button, and submit button remain visible in the viewport while the conversation area scrolls independently. The page should no longer require whole-page scrolling just to reach the input box.

### Evidence (Before & After)

Before: The issue reporter's screenshot shows the chat area pushing the input box out of view and requiring whole-page scrolling.

After:

<img width="1906" height="943" alt="d0c8e32dfb3b0a8c84a2d2ba27d6bf3b" src="https://github.com/user-attachments/assets/635f95da-b8a9-47bd-8abe-a30e7dd1fb99" />


### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | N/A |

### Environment (optional)

Local WebUI launched on Windows with a dummy Agent via `python verify_webui_layout.py`. Syntax checked with `python -m py_compile qwen_agent/gui/web_ui.py`.

## Risk & Scope

- Main risk or tradeoff: The viewport-based height may render slightly differently across browser sizes, but it keeps the input reachable and preserves the intended chat layout.
- Not validated / out of scope: Full cross-platform runtime verification on macOS and Linux.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #897

<details>
<summary>中文说明</summary>

这个 PR 调整了 WebUI 的布局，让对话区域独立滚动，同时保证消息输入框始终可见，不会因为聊天内容变长而被挤出视口。

之前使用固定高度时，页面在常见窗口大小下会被撑得过高，导致用户需要先滚动整个页面才能看到输入框。现在改成基于视口的高度，并加上轻量的 CSS 约束，让聊天体验更顺手。

</details>