### PR TITLE
Add opt-in execution gate to the un-sandboxed PythonExecutor

### DIFF
--- a/qwen_agent/tools/python_executor.py
+++ b/qwen_agent/tools/python_executor.py
@@ -31,6 +31,33 @@ from qwen_agent.tools.base import BaseTool
 from qwen_agent.utils.utils import extract_code
 
 
+class CodeExecutionNotAllowedError(RuntimeError):
+    """Raised when model-generated code is blocked before exec/eval.
+
+    PythonExecutor runs model-generated Python in the host process and is NOT
+    sandboxed (see the class docstring and README). This error is raised by the
+    opt-in safety gate below when execution has been disabled or not approved.
+    """
+    pass
+
+
+def _python_executor_is_disabled() -> bool:
+    """Hard kill-switch for environments that must never run model code in-process.
+
+    Set ``QWEN_AGENT_DISABLE_PYTHON_EXECUTOR=1`` to refuse all exec/eval. This is
+    checked inside the runtime, so it also takes effect in the worker processes
+    used by the batch executor. Default (unset) preserves existing behaviour.
+    """
+    return os.getenv('QWEN_AGENT_DISABLE_PYTHON_EXECUTOR', '0') == '1'
+
+
+def _assert_code_execution_allowed(code_piece: str) -> None:
+    if _python_executor_is_disabled():
+        raise CodeExecutionNotAllowedError(
+            'Python code execution is disabled (QWEN_AGENT_DISABLE_PYTHON_EXECUTOR=1). '
+            'PythonExecutor is not sandboxed; refusing to exec/eval model-generated code.')
+
+
 class GenericRuntime:
     GLOBAL_DICT = {}
     LOCAL_DICT = None
@@ -44,11 +71,13 @@ class GenericRuntime:
             self.exec_code(c)
 
     def exec_code(self, code_piece: str) -> None:
+        _assert_code_execution_allowed(code_piece)
         if regex.search(r'(\s|^)?input\(', code_piece) or regex.search(r'(\s|^)?os.system\(', code_piece):
             raise RuntimeError()
         exec(code_piece, self._global_vars)
 
     def eval_code(self, expr: str) -> Any:
+        _assert_code_execution_allowed(expr)
         return eval(expr, self._global_vars)
 
     def inject(self, var_dict: Dict[str, Any]) -> None:
@@ -94,6 +123,20 @@ def _check_deps_for_python_executor():
 
 # @register_tool('python_executor')  # Do not register this tool by default because it is dangerous.
 class PythonExecutor(BaseTool):
+    """Execute model-generated Python in the host process. NOT sandboxed.
+
+    This tool runs arbitrary Python in-process and is intended only for local
+    Tool-Integrated-Reasoning (TIR) math experiments, not production. If model
+    output is untrusted, prefer the sandboxed ``code_interpreter`` tool instead.
+
+    Two opt-in safety controls are available for deployments that must expose this
+    tool to model-controlled input (both default to the historical behaviour):
+
+    * ``confirm_callback`` (cfg): a callable ``(code:str) -> bool`` consulted in
+      ``call()`` before execution; return falsy to refuse the code.
+    * ``QWEN_AGENT_DISABLE_PYTHON_EXECUTOR=1`` (env): hard kill-switch that refuses
+      all exec/eval, enforced at the runtime level (also in worker processes).
+    """
     name = 'python_executor'
     description = 'For executing python code. Not sandboxed. Do not use it for production purposes.'
     parameters = {
@@ -126,6 +169,12 @@ class PythonExecutor(BaseTool):
         self.pool = Pool(multiprocess.cpu_count())
         self.timeout_length = timeout_length
 
+        # Optional human-in-the-loop / policy gate consulted before running any
+        # model-generated code. It receives the code string and must return a
+        # truthy value to allow execution. Default (None) preserves the existing
+        # behaviour for the documented, opt-in local TIR-math use case.
+        self.confirm_callback: Optional[Any] = self.cfg.get('confirm_callback', None)
+
     def call(self, params: Union[str, dict], **kwargs) -> list:
         try:
             params = json5.loads(params)
@@ -135,6 +184,17 @@ class PythonExecutor(BaseTool):
 
         if not code.strip():
             return ['', '']
+
+        # Safety gate (opt-in). PythonExecutor is not sandboxed, so a deployment
+        # that exposes it to model-controlled input can require explicit approval
+        # of each code block, or disable execution entirely via the environment
+        # variable QWEN_AGENT_DISABLE_PYTHON_EXECUTOR=1.
+        if _python_executor_is_disabled():
+            raise CodeExecutionNotAllowedError(
+                'Python code execution is disabled (QWEN_AGENT_DISABLE_PYTHON_EXECUTOR=1). '
+                'PythonExecutor is not sandboxed; refusing to run model-generated code.')
+        if self.confirm_callback is not None and not self.confirm_callback(code):
+            raise CodeExecutionNotAllowedError('Execution of the model-generated Python code was not approved.')
 
         predictions = self.apply(code)
         return predictions

--- a/tests/tools/test_python_executor_gate.py
+++ b/tests/tools/test_python_executor_gate.py
@@ -1,0 +1,114 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for the opt-in safety gate on the (un-sandboxed) PythonExecutor.
+
+PythonExecutor runs model-generated Python in the host process and is not
+sandboxed by design (the registration is commented out and it ships under the
+opt-in ``python_executor`` extra). This adds two opt-in controls that default to
+the historical behaviour:
+
+* env kill-switch ``QWEN_AGENT_DISABLE_PYTHON_EXECUTOR=1`` enforced at the
+  exec/eval sink (``GenericRuntime``), and
+* a ``confirm_callback`` policy hook consulted in ``PythonExecutor.call``.
+
+The "blocked" tests FAIL on the unpatched base (the code is exec/eval'd anyway)
+and PASS once the gate refuses execution. The sink-level tests intentionally use
+``GenericRuntime`` directly so they do not depend on the flaky multiprocess pool.
+"""
+import pytest
+
+from qwen_agent.tools.python_executor import GenericRuntime
+
+try:
+    from qwen_agent.tools.python_executor import CodeExecutionNotAllowedError
+    _HAS_GATE = True
+except ImportError:
+    CodeExecutionNotAllowedError = Exception
+    _HAS_GATE = False
+
+_needs_gate = pytest.mark.skipif(not _HAS_GATE, reason='gate not present (unpatched base)')
+
+
+# --------------------------------------------------------------------------- #
+# Sink-level kill-switch (GenericRuntime.exec_code / eval_code)
+# --------------------------------------------------------------------------- #
+def test_kill_switch_blocks_exec(monkeypatch):
+    monkeypatch.setenv('QWEN_AGENT_DISABLE_PYTHON_EXECUTOR', '1')
+    rt = GenericRuntime()
+    # On base this exec runs and sets `pwned`; the gate must refuse it instead.
+    with pytest.raises(Exception):
+        rt.exec_code('pwned = 1')
+    assert 'pwned' not in rt._global_vars, 'exec must not run when execution is disabled'
+
+
+def test_kill_switch_blocks_eval(monkeypatch):
+    monkeypatch.setenv('QWEN_AGENT_DISABLE_PYTHON_EXECUTOR', '1')
+    rt = GenericRuntime()
+    with pytest.raises(Exception):
+        rt.eval_code('1 + 1')
+
+
+@_needs_gate
+def test_kill_switch_raises_typed_error(monkeypatch):
+    monkeypatch.setenv('QWEN_AGENT_DISABLE_PYTHON_EXECUTOR', '1')
+    rt = GenericRuntime()
+    with pytest.raises(CodeExecutionNotAllowedError):
+        rt.exec_code('x = 1')
+
+
+def test_default_exec_still_works(monkeypatch):
+    """No env / no callback -> behaviour is unchanged (no false positive)."""
+    monkeypatch.delenv('QWEN_AGENT_DISABLE_PYTHON_EXECUTOR', raising=False)
+    rt = GenericRuntime()
+    rt.exec_code('answer = 6 * 7')
+    assert rt.eval_code('answer') == 42
+
+
+# --------------------------------------------------------------------------- #
+# Tool-level confirm callback (PythonExecutor.call), run before the pool
+# --------------------------------------------------------------------------- #
+def _make_executor(cfg):
+    pytest.importorskip('multiprocess')
+    pytest.importorskip('pebble')
+    pytest.importorskip('timeout_decorator')
+    from qwen_agent.tools.python_executor import PythonExecutor
+    return PythonExecutor(cfg)
+
+
+@_needs_gate
+def test_call_confirm_denied_blocks_before_pool():
+    seen = {}
+
+    def deny(code):
+        seen['code'] = code
+        return False
+
+    tool = _make_executor({'confirm_callback': deny, 'get_answer_from_stdout': True})
+    with pytest.raises(CodeExecutionNotAllowedError):
+        tool.call('{"code": "print(6*7)"}')
+    # The callback was consulted with the model code, and execution was refused.
+    assert seen.get('code') == 'print(6*7)'
+
+
+@_needs_gate
+def test_call_disabled_env_blocks(monkeypatch):
+    monkeypatch.setenv('QWEN_AGENT_DISABLE_PYTHON_EXECUTOR', '1')
+    tool = _make_executor({'get_answer_from_stdout': True})
+    with pytest.raises(CodeExecutionNotAllowedError):
+        tool.call('{"code": "print(1)"}')
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(pytest.main([__file__, '-v']))


### PR DESCRIPTION
## Add an opt-in execution gate to the un-sandboxed PythonExecutor

### Related issue

Fixes #901

### Summary

`PythonExecutor` runs model-generated Python directly in the host process and is
un-sandboxed by design — its `@register_tool` line is commented out as
\"dangerous\", it ships only under the opt-in `python_executor` extra, and the
README states it is for local testing, not production. `TIRMathAgent` installs it
and feeds it code parsed from streamed model output, so when this tool is exposed
the model effectively chooses what runs in-process. The only pre-existing check
was a narrow regex rejecting `input(` / `os.system(`, which is trivially
bypassable (`subprocess`, `os.popen`, `__import__`, `eval`, …) and is neither a
sandbox nor an approval gate.

This PR keeps the intended behaviour — the sandboxed `code_interpreter` tool
remains the recommended choice for untrusted input — but adds two **opt-in**
safety controls so deployments that must expose this tool can constrain it. Both
default to the existing behaviour, so local Tool-Integrated-Reasoning (TIR) math
use is unchanged.

### Security impact

If a deployment exposes `PythonExecutor` (directly or via `TIRMathAgent`) to
model-controlled input, a prompt-injected or otherwise unsafe model response can
reach `exec`/`eval` and execute with the privileges of the host process — there
is no sandbox and no human-in-the-loop checkpoint to stop it. The exposure is
limited (the tool is not registered by default and requires the opt-in extra),
but a deployment that opts in today has no built-in way to disable or gate that
execution. These controls give operators a default-safe off switch and an
approval hook without changing the documented local behaviour.

### Root cause

The runtime sink executes whatever code it is handed:

- `qwen_agent/tools/python_executor.py` — `GenericRuntime.exec_code` runs
  `exec(code_piece, self._global_vars)` after only the `input(` / `os.system(`
  regex.
- `qwen_agent/tools/python_executor.py` — `GenericRuntime.eval_code` runs
  `return eval(expr, self._global_vars)` with no check at all.

`PythonExecutor.call` dispatches the model-supplied `code` straight to those
methods, and `Agent._call_tool` gates only on tool-name membership in
`function_map`, so there is no approval step between model output and the sink.

### Affected sites (decisive lines)

| Path | Sink (`file:line`) | Code |
| --- | --- | --- |
| `qwen-tir-python-executor-model-code` | `qwen_agent/tools/python_executor.py:49` | `exec(code_piece, self._global_vars)` (primary sink) |
| `qwen-tir-python-executor-model-code` | `qwen_agent/tools/python_executor.py:52` | `return eval(expr, self._global_vars)` (secondary sink) |

Both sinks live in `GenericRuntime`, which is the single chokepoint every
execution path flows through (including the `pebble`/`multiprocess` batch worker
path), so guarding it there closes the whole class.

### Change

In `qwen_agent/tools/python_executor.py`:

- **Kill-switch:** setting `QWEN_AGENT_DISABLE_PYTHON_EXECUTOR=1` refuses all
  exec/eval. It is enforced inside `GenericRuntime.exec_code` / `eval_code` (the
  actual sink), so it also takes effect in the worker processes used by the batch
  executor (the env var is inherited by children).
- **Approval hook:** a `confirm_callback` config option — a `(code: str) -> bool`
  callable consulted in `call()` **before** any code is dispatched to the pool;
  returning a falsy value refuses the code. The check is done in-process to avoid
  the cross-process pickling limitation of passing a callable into the worker
  pool.
- Both refusals raise a new `CodeExecutionNotAllowedError(RuntimeError)`.
- The class docstring now states the tool is un-sandboxed, recommends
  `code_interpreter` for untrusted input, and documents both controls.

No public signature changes. With no env var set and no callback configured, the
behaviour is identical to before — so `TIRMathAgent`'s documented local use is
untouched.

### Backwards compatibility

Fully backwards compatible. The new behaviour is gated entirely behind an unset
environment variable and an unconfigured (`None`) callback, both of which default
to the historical \"just run it\" path. Stdlib only (`os` was already imported); no
new dependencies.

### Tests

New file `tests/tools/test_python_executor_gate.py`:

- With the kill-switch set, `GenericRuntime.exec_code` / `eval_code` must raise
  and must **not** run the code. The sink-level tests use `GenericRuntime`
  directly so they do not depend on the flaky multiprocess pool.
- The tool-level `confirm_callback` and env kill-switch refuse before execution
  (these import the new symbol lazily, so they skip cleanly on an unpatched
  checkout).
- With neither control set, execution still works (`answer == 42`) — guards
  against a false positive / regression.

Fail-before / pass-after (covers the 1 exploit path):

```
# BEFORE (fix reverted, test kept) — base runs the code despite the kill-switch
$ python -m pytest tests/tools/test_python_executor_gate.py -q
...
>       with pytest.raises(Exception):
E       Failed: DID NOT RAISE Exception
2 failed, 1 passed, 3 skipped

# AFTER (this change)
$ python -m pytest tests/tools/test_python_executor_gate.py -q
6 passed
```

### Checklist

- [x] The change is backwards compatible and defaults to the existing behaviour.
- [x] Added a regression test that fails before the change and passes after it.
- [x] `flake8` clean under the repo's `.pre-commit-config.yaml` flake8 args.
- [x] No new third-party dependencies (stdlib only).
- [x] Linked the tracking issue above (`Fixes #901`).
- [ ] Ran the full test suite locally.
- [ ] Signed the contributor agreement / CLA, if the project requires one.

### Notes

- The commit is signed off under the DCO (`Signed-off-by` trailer).
- By-design behaviour is preserved; the new controls are opt-in and default-safe.
- To keep this report safe, it intentionally does not include a copy-pasteable
  exploit. If you would prefer to discuss the details privately first, I am happy
  to do so.