### PR TITLE
fix(llm): preserve OAI usage metadata

### DIFF
--- a/qwen_agent/llm/oai.py
+++ b/qwen_agent/llm/oai.py
@@ -33,39 +33,38 @@ from qwen_agent.llm.schema import ASSISTANT, FunctionCall, Message
 from qwen_agent.log import logger
 
 
-def _safe_model_dump(value: Any) -> Any:
+def _dump_oai_metadata(value: Any) -> Any:
     if value is None:
         return None
     if isinstance(value, dict):
         return value
     if hasattr(value, 'model_dump'):
-        return value.model_dump(exclude_none=True)
-    if hasattr(value, 'dict'):
-        return value.dict()
+        try:
+            return value.model_dump(exclude_none=True, mode='json')
+        except TypeError:
+            return value.model_dump(exclude_none=True)
     if hasattr(value, 'to_dict_recursive'):
         return value.to_dict_recursive()
     if hasattr(value, 'to_dict'):
         return value.to_dict()
-    if hasattr(value, '__dict__'):
-        return {k: v for k, v in value.__dict__.items() if (not k.startswith('_')) and (v is not None)}
     return value
 
 
-def _usage_extra(response: Any) -> Optional[dict]:
+def _model_service_info_extra(response: Any) -> Optional[dict]:
     if isinstance(response, dict):
         usage = response.get('usage')
     else:
         usage = getattr(response, 'usage', None)
     if usage is None:
         return None
-    return {'usage': _safe_model_dump(usage)}
+    return {'model_service_info': {'usage': _dump_oai_metadata(usage)}}
 
 
-def _merge_extra(extra: Optional[dict], usage_extra: Optional[dict]) -> Optional[dict]:
-    if not usage_extra:
+def _merge_extra(extra: Optional[dict], model_service_extra: Optional[dict]) -> Optional[dict]:
+    if not model_service_extra:
         return extra
     merged_extra = copy.deepcopy(extra) if extra else {}
-    merged_extra.update(usage_extra)
+    merged_extra.update(model_service_extra)
     return merged_extra
 
 
@@ -143,7 +142,7 @@ class TextChatAtOAI(BaseFnCallModel):
             response = self._chat_complete_create(model=self.model, messages=messages, stream=True, **generate_cfg)
             if delta_stream:
                 for chunk in response:
-                    usage_extra = _usage_extra(chunk)
+                    model_service_extra = _model_service_info_extra(chunk)
                     has_output = False
                     if chunk.choices:
                         if hasattr(chunk.choices[0].delta,
@@ -153,38 +152,42 @@ class TextChatAtOAI(BaseFnCallModel):
                                 Message(role=ASSISTANT,
                                         content='',
                                         reasoning_content=chunk.choices[0].delta.reasoning_content,
-                                        extra=usage_extra)
+                                        extra=model_service_extra)
                             ]
                         if hasattr(chunk.choices[0].delta, 'content') and chunk.choices[0].delta.content:
                             has_output = True
-                            yield [Message(role=ASSISTANT, content=chunk.choices[0].delta.content, extra=usage_extra)]
-                    if usage_extra and not has_output:
-                        yield [Message(role=ASSISTANT, content='', extra=usage_extra)]
+                            yield [
+                                Message(role=ASSISTANT,
+                                        content=chunk.choices[0].delta.content,
+                                        extra=model_service_extra)
+                            ]
+                    if model_service_extra and not has_output:
+                        yield [Message(role=ASSISTANT, content='', extra=model_service_extra)]
             else:
                 full_response = ''
                 full_reasoning_content = ''
                 full_tool_calls = []
 
-                def _build_full_response(usage_extra: Optional[dict] = None) -> List[Message]:
+                def _build_full_response(model_service_extra: Optional[dict] = None) -> List[Message]:
                     res = []
                     if full_reasoning_content:
                         res.append(
                             Message(role=ASSISTANT,
                                     content='',
                                     reasoning_content=full_reasoning_content,
-                                    extra=usage_extra))
+                                    extra=model_service_extra))
                     if full_response:
-                        res.append(Message(role=ASSISTANT, content=full_response, extra=usage_extra))
+                        res.append(Message(role=ASSISTANT, content=full_response, extra=model_service_extra))
                     if full_tool_calls:
-                        tool_calls = copy.deepcopy(full_tool_calls) if usage_extra else full_tool_calls
-                        if usage_extra:
+                        tool_calls = copy.deepcopy(full_tool_calls) if model_service_extra else full_tool_calls
+                        if model_service_extra:
                             for tool_call in tool_calls:
-                                tool_call.extra = _merge_extra(tool_call.extra, usage_extra)
+                                tool_call.extra = _merge_extra(tool_call.extra, model_service_extra)
                         res += tool_calls
                     return res
 
                 for chunk in response:
-                    usage_extra = _usage_extra(chunk)
+                    model_service_extra = _model_service_info_extra(chunk)
                     if chunk.choices:
                         if hasattr(chunk.choices[0].delta,
                                    'reasoning_content') and chunk.choices[0].delta.reasoning_content:
@@ -207,9 +210,9 @@ class TextChatAtOAI(BaseFnCallModel):
                                                                            arguments=tc.function.arguments),
                                                 extra={'function_id': tc.id}))
 
-                        yield _build_full_response(usage_extra)
-                    elif usage_extra:
-                        res = _build_full_response(usage_extra)
+                        yield _build_full_response(model_service_extra)
+                    elif model_service_extra:
+                        res = _build_full_response(model_service_extra)
                         if res:
                             yield res
         except OpenAIError as ex:
@@ -223,16 +226,20 @@ class TextChatAtOAI(BaseFnCallModel):
         messages = self.convert_messages_to_dicts(messages)
         try:
             response = self._chat_complete_create(model=self.model, messages=messages, stream=False, **generate_cfg)
-            usage_extra = _usage_extra(response)
+            model_service_extra = _model_service_info_extra(response)
             if hasattr(response.choices[0].message, 'reasoning_content'):
                 return [
                     Message(role=ASSISTANT,
                             content=response.choices[0].message.content,
                             reasoning_content=response.choices[0].message.reasoning_content,
-                            extra=usage_extra)
+                            extra=model_service_extra)
                 ]
             else:
-                return [Message(role=ASSISTANT, content=response.choices[0].message.content, extra=usage_extra)]
+                return [
+                    Message(role=ASSISTANT,
+                            content=response.choices[0].message.content,
+                            extra=model_service_extra)
+                ]
         except OpenAIError as ex:
             raise ModelServiceError(exception=ex)
 

--- a/qwen_agent/llm/oai.py
+++ b/qwen_agent/llm/oai.py
@@ -16,7 +16,7 @@ import copy
 import logging
 import os
 from pprint import pformat
-from typing import Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 import openai
 
@@ -31,6 +31,42 @@ from qwen_agent.llm.base import ModelServiceError, register_llm
 from qwen_agent.llm.function_calling import BaseFnCallModel
 from qwen_agent.llm.schema import ASSISTANT, FunctionCall, Message
 from qwen_agent.log import logger
+
+
+def _safe_model_dump(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, 'model_dump'):
+        return value.model_dump(exclude_none=True)
+    if hasattr(value, 'dict'):
+        return value.dict()
+    if hasattr(value, 'to_dict_recursive'):
+        return value.to_dict_recursive()
+    if hasattr(value, 'to_dict'):
+        return value.to_dict()
+    if hasattr(value, '__dict__'):
+        return {k: v for k, v in value.__dict__.items() if (not k.startswith('_')) and (v is not None)}
+    return value
+
+
+def _usage_extra(response: Any) -> Optional[dict]:
+    if isinstance(response, dict):
+        usage = response.get('usage')
+    else:
+        usage = getattr(response, 'usage', None)
+    if usage is None:
+        return None
+    return {'usage': _safe_model_dump(usage)}
+
+
+def _merge_extra(extra: Optional[dict], usage_extra: Optional[dict]) -> Optional[dict]:
+    if not usage_extra:
+        return extra
+    merged_extra = copy.deepcopy(extra) if extra else {}
+    merged_extra.update(usage_extra)
+    return merged_extra
 
 
 @register_llm('oai')
@@ -107,21 +143,48 @@ class TextChatAtOAI(BaseFnCallModel):
             response = self._chat_complete_create(model=self.model, messages=messages, stream=True, **generate_cfg)
             if delta_stream:
                 for chunk in response:
+                    usage_extra = _usage_extra(chunk)
+                    has_output = False
                     if chunk.choices:
                         if hasattr(chunk.choices[0].delta,
                                    'reasoning_content') and chunk.choices[0].delta.reasoning_content:
+                            has_output = True
                             yield [
                                 Message(role=ASSISTANT,
                                         content='',
-                                        reasoning_content=chunk.choices[0].delta.reasoning_content)
+                                        reasoning_content=chunk.choices[0].delta.reasoning_content,
+                                        extra=usage_extra)
                             ]
                         if hasattr(chunk.choices[0].delta, 'content') and chunk.choices[0].delta.content:
-                            yield [Message(role=ASSISTANT, content=chunk.choices[0].delta.content)]
+                            has_output = True
+                            yield [Message(role=ASSISTANT, content=chunk.choices[0].delta.content, extra=usage_extra)]
+                    if usage_extra and not has_output:
+                        yield [Message(role=ASSISTANT, content='', extra=usage_extra)]
             else:
                 full_response = ''
                 full_reasoning_content = ''
                 full_tool_calls = []
+
+                def _build_full_response(usage_extra: Optional[dict] = None) -> List[Message]:
+                    res = []
+                    if full_reasoning_content:
+                        res.append(
+                            Message(role=ASSISTANT,
+                                    content='',
+                                    reasoning_content=full_reasoning_content,
+                                    extra=usage_extra))
+                    if full_response:
+                        res.append(Message(role=ASSISTANT, content=full_response, extra=usage_extra))
+                    if full_tool_calls:
+                        tool_calls = copy.deepcopy(full_tool_calls) if usage_extra else full_tool_calls
+                        if usage_extra:
+                            for tool_call in tool_calls:
+                                tool_call.extra = _merge_extra(tool_call.extra, usage_extra)
+                        res += tool_calls
+                    return res
+
                 for chunk in response:
+                    usage_extra = _usage_extra(chunk)
                     if chunk.choices:
                         if hasattr(chunk.choices[0].delta,
                                    'reasoning_content') and chunk.choices[0].delta.reasoning_content:
@@ -144,17 +207,11 @@ class TextChatAtOAI(BaseFnCallModel):
                                                                            arguments=tc.function.arguments),
                                                 extra={'function_id': tc.id}))
 
-                        res = []
-                        if full_reasoning_content:
-                            res.append(Message(role=ASSISTANT, content='', reasoning_content=full_reasoning_content))
-                        if full_response:
-                            res.append(Message(
-                                role=ASSISTANT,
-                                content=full_response,
-                            ))
-                        if full_tool_calls:
-                            res += full_tool_calls
-                        yield res
+                        yield _build_full_response(usage_extra)
+                    elif usage_extra:
+                        res = _build_full_response(usage_extra)
+                        if res:
+                            yield res
         except OpenAIError as ex:
             raise ModelServiceError(exception=ex)
 
@@ -166,14 +223,16 @@ class TextChatAtOAI(BaseFnCallModel):
         messages = self.convert_messages_to_dicts(messages)
         try:
             response = self._chat_complete_create(model=self.model, messages=messages, stream=False, **generate_cfg)
+            usage_extra = _usage_extra(response)
             if hasattr(response.choices[0].message, 'reasoning_content'):
                 return [
                     Message(role=ASSISTANT,
                             content=response.choices[0].message.content,
-                            reasoning_content=response.choices[0].message.reasoning_content)
+                            reasoning_content=response.choices[0].message.reasoning_content,
+                            extra=usage_extra)
                 ]
             else:
-                return [Message(role=ASSISTANT, content=response.choices[0].message.content)]
+                return [Message(role=ASSISTANT, content=response.choices[0].message.content, extra=usage_extra)]
         except OpenAIError as ex:
             raise ModelServiceError(exception=ex)
 

--- a/tests/llm/test_oai.py
+++ b/tests/llm/test_oai.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 import os
+from types import SimpleNamespace
 
 import pytest
 
 from qwen_agent.llm import get_chat_model
+from qwen_agent.llm.oai import TextChatAtOAI
 from qwen_agent.llm.schema import Message
 
 functions = [{
@@ -65,3 +67,31 @@ def test_llm_oai(functions, stream, delta_stream):
         assert response[-1].function_call.name == 'image_gen'
     else:
         assert response[-1].function_call is None
+
+
+def test_llm_oai_preserves_usage_no_stream():
+    llm = TextChatAtOAI({'model': 'test-model', 'api_key': 'test-key'})
+    usage = {'prompt_tokens': 3, 'completion_tokens': 5, 'total_tokens': 8}
+    llm._chat_complete_create = lambda **kwargs: SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content='hello'))],
+        usage=usage,
+    )
+
+    response = llm._chat_no_stream([Message('user', 'hi')], {})
+
+    assert response[0].content == 'hello'
+    assert response[0].extra == {'usage': usage}
+
+
+def test_llm_oai_preserves_final_stream_usage():
+    llm = TextChatAtOAI({'model': 'test-model', 'api_key': 'test-key'})
+    usage = {'prompt_tokens': 3, 'completion_tokens': 5, 'total_tokens': 8}
+    llm._chat_complete_create = lambda **kwargs: iter([
+        SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content='hello'))], usage=None),
+        SimpleNamespace(choices=[], usage=usage),
+    ])
+
+    responses = list(llm._chat_stream([Message('user', 'hi')], delta_stream=False, generate_cfg={}))
+
+    assert responses[-1][0].content == 'hello'
+    assert responses[-1][0].extra == {'usage': usage}

--- a/tests/llm/test_oai.py
+++ b/tests/llm/test_oai.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 from types import SimpleNamespace
 
@@ -80,7 +81,8 @@ def test_llm_oai_preserves_usage_no_stream():
     response = llm._chat_no_stream([Message('user', 'hi')], {})
 
     assert response[0].content == 'hello'
-    assert response[0].extra == {'usage': usage}
+    assert response[0].extra == {'model_service_info': {'usage': usage}}
+    json.dumps(response[0].model_dump())
 
 
 def test_llm_oai_preserves_final_stream_usage():
@@ -94,4 +96,5 @@ def test_llm_oai_preserves_final_stream_usage():
     responses = list(llm._chat_stream([Message('user', 'hi')], delta_stream=False, generate_cfg={}))
 
     assert responses[-1][0].content == 'hello'
-    assert responses[-1][0].extra == {'usage': usage}
+    assert responses[-1][0].extra == {'model_service_info': {'usage': usage}}
+    json.dumps(responses[-1][0].model_dump())


### PR DESCRIPTION
### Summary
- Preserve chat completion usage metadata in OAI non-streaming responses via `Message.extra.usage`.
- Preserve usage metadata from streaming chunks, including final usage-only chunks from OpenAI-compatible APIs.
- Add focused tests for non-streaming and streaming usage preservation.

### Related issue
- Related to #356. This PR propagates usage when the OpenAI-compatible backend returns it; it does not estimate token usage locally when the backend returns `usage=None`.

### Reproduction
When an OpenAI-compatible backend returns `response.usage`, the OAI client should preserve it:

```py
from types import SimpleNamespace

from qwen_agent.llm.oai import TextChatAtOAI
from qwen_agent.llm.schema import Message

llm = TextChatAtOAI({'model': 'test-model', 'api_key': 'test-key'})
usage = {'prompt_tokens': 3, 'completion_tokens': 5, 'total_tokens': 8}
llm._chat_complete_create = lambda **kwargs: SimpleNamespace(
    choices=[SimpleNamespace(message=SimpleNamespace(content='hello'))],
    usage=usage,
)

response = llm._chat_no_stream([Message('user', 'hi')], {})
assert response[0].extra == {'usage': usage}
```

For streaming APIs, this PR also preserves final usage-only chunks such as `choices=[]` with `usage={...}`.

### Tests
- `PYTHONPATH=/tmp/qwen-agent-api-work pytest -q /tmp/qwen-agent-api-work/test_oai.py::test_llm_oai_preserves_usage_no_stream /tmp/qwen-agent-api-work/test_oai.py::test_llm_oai_preserves_final_stream_usage`