### PR TITLE
fix: avoid persisting run_server api keys

### DIFF
--- a/qwen_server/assistant_server.py
+++ b/qwen_server/assistant_server.py
@@ -1,11 +1,11 @@
 # Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,7 +32,8 @@ from qwen_agent.log import logger
 from qwen_server.schema import GlobalConfig
 from qwen_server.utils import read_history, read_meta_data_by_condition, save_history
 
-server_config_path = Path(__file__).resolve().parent / 'server_config.json'
+default_config_path = Path(__file__).resolve().parent / 'server_config.json'
+server_config_path = Path(os.environ.get('QWEN_SERVER_CONFIG') or default_config_path)
 with open(server_config_path, 'r') as f:
     server_config = json.load(f)
     server_config = GlobalConfig(**server_config)

--- a/qwen_server/database_server.py
+++ b/qwen_server/database_server.py
@@ -1,11 +1,11 @@
 # Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,7 +36,9 @@ from qwen_server.schema import GlobalConfig
 from qwen_server.utils import rm_browsing_meta_data, save_browsing_meta_data, save_history
 
 # Read config
-with open(Path(__file__).resolve().parent / 'server_config.json', 'r') as f:
+default_config_path = Path(__file__).resolve().parent / 'server_config.json'
+server_config_path = Path(os.environ.get('QWEN_SERVER_CONFIG') or default_config_path)
+with open(server_config_path, 'r') as f:
     server_config = json.load(f)
     server_config = GlobalConfig(**server_config)
 

--- a/qwen_server/workstation_server.py
+++ b/qwen_server/workstation_server.py
@@ -1,11 +1,11 @@
 # Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,9 @@ from qwen_server.schema import GlobalConfig
 from qwen_server.utils import read_meta_data_by_condition, save_browsing_meta_data
 
 # Read config
-with open(Path(__file__).resolve().parent / 'server_config.json', 'r') as f:
+default_config_path = Path(__file__).resolve().parent / 'server_config.json'
+server_config_path = Path(os.environ.get('QWEN_SERVER_CONFIG') or default_config_path)
+with open(server_config_path, 'r') as f:
     server_config = json.load(f)
     server_config = GlobalConfig(**server_config)
 llm_config = None

--- a/run_server.py
+++ b/run_server.py
@@ -1,11 +1,11 @@
 # Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,9 @@ import sys
 from pathlib import Path
 
 from qwen_server.schema import GlobalConfig
+
+SERVER_CONFIG_ENV = 'QWEN_SERVER_CONFIG'
+SECRET_FIELDS = {'api_key'}
 
 
 def parse_args():
@@ -77,20 +80,46 @@ def parse_args():
     return args
 
 
-def update_config(server_config, args, server_config_path):
-    server_config.server.model_server = args.model_server
-    server_config.server.api_key = args.api_key
-    server_config.server.llm = args.llm
-    server_config.server.server_host = args.server_host
-    server_config.server.max_ref_token = args.max_ref_token
-    server_config.server.workstation_port = args.workstation_port
-
-    with open(server_config_path, 'w') as f:
+def _dump_config(server_config, config_path):
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_path, 'w') as f:
         try:
             cfg = server_config.model_dump_json()
         except AttributeError:  # for pydantic v1
             cfg = server_config.json()
         json.dump(json.loads(cfg), f, ensure_ascii=False, indent=4)
+
+
+def _redact_config(config):
+    try:
+        config_dict = json.loads(config.model_dump_json())
+    except AttributeError:  # for pydantic v1
+        config_dict = json.loads(config.json())
+
+    for section in config_dict.values():
+        if isinstance(section, dict):
+            for field in SECRET_FIELDS:
+                if section.get(field):
+                    section[field] = '***'
+    return config_dict
+
+
+def update_config(server_config, args, server_config_path, runtime_config_path=None):
+    original_api_key = server_config.server.api_key
+
+    server_config.server.model_server = args.model_server
+    server_config.server.api_key = args.api_key or original_api_key
+    server_config.server.llm = args.llm
+    server_config.server.server_host = args.server_host
+    server_config.server.max_ref_token = args.max_ref_token
+    server_config.server.workstation_port = args.workstation_port
+
+    if runtime_config_path is not None:
+        _dump_config(server_config, runtime_config_path)
+
+    server_config.server.api_key = original_api_key
+    _dump_config(server_config, server_config_path)
+    server_config.server.api_key = args.api_key or original_api_key
     return server_config
 
 
@@ -100,7 +129,9 @@ def main():
     with open(server_config_path, 'r') as f:
         server_config = json.load(f)
         server_config = GlobalConfig(**server_config)
-    server_config = update_config(server_config, args, server_config_path)
+    runtime_config_path = Path(__file__).resolve().parent / 'workspace/server_config.local.json'
+    server_config = update_config(server_config, args, server_config_path, runtime_config_path)
+    os.environ[SERVER_CONFIG_ENV] = str(runtime_config_path)
 
     os.makedirs(server_config.path.work_space_root, exist_ok=True)
     os.makedirs(server_config.path.download_root, exist_ok=True)
@@ -112,7 +143,7 @@ def main():
     os.environ['M6_CODE_INTERPRETER_WORK_DIR'] = code_interpreter_work_dir
 
     from qwen_agent.utils.utils import append_signal_handler, get_local_ip, logger
-    logger.info(server_config)
+    logger.info(_redact_config(server_config))
 
     if args.server_host == '0.0.0.0':
         static_url = get_local_ip()

--- a/tests/qwen_server/test_run_server_config.py
+++ b/tests/qwen_server/test_run_server_config.py
@@ -1,0 +1,76 @@
+import json
+from types import SimpleNamespace
+
+from qwen_server.schema import GlobalConfig
+from run_server import _redact_config, update_config
+
+
+def _load_config():
+    with open('qwen_server/server_config.json', 'r') as f:
+        return GlobalConfig(**json.load(f))
+
+
+def test_update_config_keeps_cli_api_key_out_of_tracked_config(tmp_path):
+    server_config = _load_config()
+    server_config.server.api_key = 'existing-file-key'
+    tracked_config_path = tmp_path / 'server_config.json'
+    runtime_config_path = tmp_path / 'workspace' / 'server_config.local.json'
+
+    args = SimpleNamespace(
+        model_server='https://model.example/v1',
+        api_key='runtime-secret-key',
+        llm='qwen-max',
+        server_host='127.0.0.1',
+        max_ref_token=1234,
+        workstation_port=9001,
+    )
+
+    runtime_config = update_config(server_config, args, tracked_config_path, runtime_config_path)
+
+    assert runtime_config.server.api_key == 'runtime-secret-key'
+
+    tracked_config = json.loads(tracked_config_path.read_text())
+    assert tracked_config['server']['api_key'] == 'existing-file-key'
+    assert tracked_config['server']['api_key'] != 'runtime-secret-key'
+    assert tracked_config['server']['model_server'] == 'https://model.example/v1'
+    assert tracked_config['server']['llm'] == 'qwen-max'
+
+    local_runtime_config = json.loads(runtime_config_path.read_text())
+    assert local_runtime_config['server']['api_key'] == 'runtime-secret-key'
+    assert local_runtime_config['server']['model_server'] == 'https://model.example/v1'
+
+
+def test_update_config_uses_existing_api_key_when_cli_key_omitted(tmp_path):
+    server_config = _load_config()
+    server_config.server.api_key = 'existing-file-key'
+    tracked_config_path = tmp_path / 'server_config.json'
+    runtime_config_path = tmp_path / 'workspace' / 'server_config.local.json'
+
+    args = SimpleNamespace(
+        model_server='https://model.example/v1',
+        api_key='',
+        llm='qwen-max',
+        server_host='127.0.0.1',
+        max_ref_token=1234,
+        workstation_port=9001,
+    )
+
+    runtime_config = update_config(server_config, args, tracked_config_path, runtime_config_path)
+
+    assert runtime_config.server.api_key == 'existing-file-key'
+
+    tracked_config = json.loads(tracked_config_path.read_text())
+    assert tracked_config['server']['api_key'] == 'existing-file-key'
+
+    local_runtime_config = json.loads(runtime_config_path.read_text())
+    assert local_runtime_config['server']['api_key'] == 'existing-file-key'
+
+
+def test_redact_config_masks_api_key():
+    server_config = _load_config()
+    server_config.server.api_key = 'runtime-secret-key'
+
+    redacted = _redact_config(server_config)
+
+    assert redacted['server']['api_key'] == '***'
+    assert 'runtime-secret-key' not in json.dumps(redacted)


### PR DESCRIPTION
Fixes #904.

## Summary
- keep CLI/runtime API keys out of the tracked `qwen_server/server_config.json` template
- pass runtime overrides to child server processes through an untracked `workspace/server_config.local.json` path
- redact API keys before logging startup config
- let child server modules read the runtime config path from `QWEN_SERVER_CONFIG`, with the existing template as fallback

## Tests
- `.venv/bin/python -m pytest tests/qwen_server/test_run_server_config.py -q`
- `.venv/bin/python -m compileall run_server.py qwen_server/assistant_server.py qwen_server/database_server.py qwen_server/workstation_server.py tests/qwen_server/test_run_server_config.py`
- `uv run --with flake8 flake8 run_server.py qwen_server/assistant_server.py qwen_server/database_server.py qwen_server/workstation_server.py tests/qwen_server/test_run_server_config.py --max-line-length=300 --extend-ignore=E231,E702,E251,W604`
- `uv run --with isort isort --check-only --line-length 120 run_server.py qwen_server/assistant_server.py qwen_server/database_server.py qwen_server/workstation_server.py tests/qwen_server/test_run_server_config.py`
- `uv run --with yapf yapf --style '{based_on_style: google, column_limit: 120}' --diff run_server.py qwen_server/assistant_server.py qwen_server/database_server.py qwen_server/workstation_server.py tests/qwen_server/test_run_server_config.py`
- `git diff --check origin/main..HEAD && git diff --check`