### PR TITLE
fix(server): do not persist or log the API key in run_server (#904)

### DIFF
--- a/run_server.py
+++ b/run_server.py
@@ -77,6 +77,26 @@ def parse_args():
     return args
 
 
+def api_key_env_var(model_server):
+    """Return the env var the model backend reads the key from.
+
+    DashScope reads ``DASHSCOPE_API_KEY``; OpenAI API-compatible endpoints
+    (vLLM, Ollama, ...) read ``OPENAI_API_KEY``.
+    """
+    return 'DASHSCOPE_API_KEY' if model_server == 'dashscope' else 'OPENAI_API_KEY'
+
+
+def redact_secrets(server_config):
+    """Return a config dict safe to log, with the API key masked."""
+    try:
+        cfg = json.loads(server_config.model_dump_json())
+    except AttributeError:  # for pydantic v1
+        cfg = json.loads(server_config.json())
+    if cfg.get('server', {}).get('api_key'):
+        cfg['server']['api_key'] = '***'
+    return cfg
+
+
 def update_config(server_config, args, server_config_path):
     server_config.server.model_server = args.model_server
     server_config.server.api_key = args.api_key
@@ -85,12 +105,18 @@ def update_config(server_config, args, server_config_path):
     server_config.server.max_ref_token = args.max_ref_token
     server_config.server.workstation_port = args.workstation_port
 
+    try:
+        cfg = server_config.model_dump_json()
+    except AttributeError:  # for pydantic v1
+        cfg = server_config.json()
+    cfg = json.loads(cfg)
+    # Security: never persist the API key to the (git-tracked) config file.
+    # The key is passed to the child servers through an environment variable
+    # instead (see main()); the LLM backends fall back to DASHSCOPE_API_KEY /
+    # OPENAI_API_KEY when the config api_key is empty.
+    cfg['server']['api_key'] = ''
     with open(server_config_path, 'w') as f:
-        try:
-            cfg = server_config.model_dump_json()
-        except AttributeError:  # for pydantic v1
-            cfg = server_config.json()
-        json.dump(json.loads(cfg), f, ensure_ascii=False, indent=4)
+        json.dump(cfg, f, ensure_ascii=False, indent=4)
     return server_config
 
 
@@ -102,6 +128,13 @@ def main():
         server_config = GlobalConfig(**server_config)
     server_config = update_config(server_config, args, server_config_path)
 
+    # Security: hand the API key to the child servers via the environment
+    # instead of the on-disk config file, so the secret never touches a
+    # tracked file. Only set it when provided, to avoid clobbering a key the
+    # user may already have exported.
+    if args.api_key:
+        os.environ[api_key_env_var(args.model_server)] = args.api_key
+
     os.makedirs(server_config.path.work_space_root, exist_ok=True)
     os.makedirs(server_config.path.download_root, exist_ok=True)
 
@@ -112,7 +145,7 @@ def main():
     os.environ['M6_CODE_INTERPRETER_WORK_DIR'] = code_interpreter_work_dir
 
     from qwen_agent.utils.utils import append_signal_handler, get_local_ip, logger
-    logger.info(server_config)
+    logger.info(redact_secrets(server_config))
 
     if args.server_host == '0.0.0.0':
         static_url = get_local_ip()

--- a/test_run_server_api_key.py
+++ b/test_run_server_api_key.py
@@ -1,0 +1,79 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for issue #904: API keys must not be persisted to the
+tracked config file or written to logs.
+
+Place this file at the repository root and run:
+
+    pip install -e .
+    pytest test_run_server_api_key.py -v
+"""
+import json
+import sys
+from pathlib import Path
+
+# Locate the repo root (the directory that contains run_server.py), whether
+# this test sits at the root or under tests/.
+REPO_ROOT = Path(__file__).resolve().parent
+while not (REPO_ROOT / 'run_server.py').exists() and REPO_ROOT != REPO_ROOT.parent:
+    REPO_ROOT = REPO_ROOT.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import run_server  # noqa: E402
+from qwen_server.schema import GlobalConfig  # noqa: E402
+
+SECRET = 'sk-supersecret-DO-NOT-LEAK-1234567890'
+
+
+def _base_config():
+    with open(REPO_ROOT / 'qwen_server' / 'server_config.json') as f:
+        return GlobalConfig(**json.load(f))
+
+
+class _Args:
+    model_server = 'dashscope'
+    api_key = SECRET
+    llm = 'qwen-plus'
+    server_host = '127.0.0.1'
+    max_ref_token = 4000
+    workstation_port = 7864
+
+
+def test_api_key_not_written_to_config_file(tmp_path):
+    out = tmp_path / 'server_config.json'
+    run_server.update_config(_base_config(), _Args(), out)
+
+    text = out.read_text()
+    assert SECRET not in text, 'API key leaked into the persisted config file'
+    assert json.loads(text)['server']['api_key'] == ''
+
+
+def test_in_memory_config_still_has_key(tmp_path):
+    # Functionality must be preserved: the running process keeps the real key.
+    out = tmp_path / 'server_config.json'
+    cfg = run_server.update_config(_base_config(), _Args(), out)
+    assert cfg.server.api_key == SECRET
+
+
+def test_log_output_is_redacted():
+    cfg = _base_config()
+    cfg.server.api_key = SECRET
+    redacted = run_server.redact_secrets(cfg)
+    assert redacted['server']['api_key'] == '***'
+    assert SECRET not in json.dumps(redacted)
+
+
+def test_provider_env_var_selection():
+    assert run_server.api_key_env_var('dashscope') == 'DASHSCOPE_API_KEY'
+    assert run_server.api_key_env_var('http://localhost:8000/v1') == 'OPENAI_API_KEY'


### PR DESCRIPTION
### What

`run_server.py` writes the `--api_key` CLI value into the git-tracked `qwen_server/server_config.json` and logs the whole config (including the key) via `logger.info(server_config)`. This persists and prints the user's DashScope / OpenAI credential in plaintext. Fixes #904.

### Why it is safe to stop persisting the key

The child servers (`assistant_server.py`, `workstation_server.py`, `database_server.py`) build their `llm_config` from the config file's `server.api_key`. When that value is empty, the LLM backends already fall back to the standard environment variables:

- `qwen_agent/llm/qwen_dashscope.py`: `api_key = os.getenv('DASHSCOPE_API_KEY', ...)`
- `qwen_agent/llm/oai.py`: `api_key = api_key or os.getenv('OPENAI_API_KEY')`

So we can pass the key to the child processes through the environment instead of the on-disk file, with no behavior change for the user.

### Changes (all in `run_server.py`)

1. `update_config()` now writes the config with `api_key` blanked out, so the secret never lands in the tracked file.
2. `main()` exports the key to `DASHSCOPE_API_KEY` / `OPENAI_API_KEY` (chosen by `--model_server`) before spawning the child servers, which inherit it.
3. `logger.info(...)` now logs a redacted copy (`api_key='***'`).

No new dependencies. Functionality is unchanged: the running process still uses the real key.

### Testing

Added `test_run_server_api_key.py`:

- the key is not written to the persisted config file
- the in-memory config still carries the real key (no regression)
- log output is redacted
- the key is routed to the correct provider env var

```
pytest test_run_server_api_key.py -v
```
