### PR TITLE
Bound web search requests and add Xquik tweet search

### DIFF
--- a/qwen-agent-docs/website/content/en/guide/get_started/configuration.md
+++ b/qwen-agent-docs/website/content/en/guide/get_started/configuration.md
@@ -157,7 +157,33 @@ There are two subtypes of dictionary formats:
 
 ---
 
-### 2. Handling Duplicate Tool Names
+### 2. Xquik Tweet Search
+
+Set `XQUIK_API_KEY`, then add the built-in tool by name:
+
+```bash
+export XQUIK_API_KEY=<your_api_key>
+```
+
+```python
+bot = Assistant(
+    llm=llm_cfg,
+    function_list=["xquik_tweet_search"],
+)
+```
+
+The tool accepts X search syntax, post IDs, and status URLs. Its JSON response
+contains `tweets`, `has_more`, and `next_cursor`. Pass `next_cursor` back as
+`cursor` to continue pagination. See the
+[Xquik API documentation](https://docs.xquik.com/api-reference/overview) for
+search syntax and authentication details.
+
+Xquik is an independent third-party service. Not affiliated with X Corp.
+"Twitter" and "X" are trademarks of X Corp.
+
+---
+
+### 3. Handling Duplicate Tool Names
 
 - If multiple entries attempt to register a tool with the **same name**, the system:
    **Overwrites** any previous tool with the **latest occurrence** in the list.
@@ -166,7 +192,7 @@ There are two subtypes of dictionary formats:
 
 ---
 
-### 3. Full Usage Example
+### 4. Full Usage Example
 
 ```python
 tools = [
@@ -205,7 +231,7 @@ bot = Assistant(
 
 ---
 
-### 4. Common Errors
+### 5. Common Errors
 
 | Error | Cause | Solution |
 |------|------|--------|
@@ -214,7 +240,7 @@ bot = Assistant(
 
 ---
 
-### 5. Summary
+### 6. Summary
 
 The `function_list` parameter is designed to **flexibly support multiple tool integration strategies**:
 - **Simple**: Use strings for quick access to built-in tools.

--- a/qwen-agent-docs/website/content/en/guide/get_started/features.md
+++ b/qwen-agent-docs/website/content/en/guide/get_started/features.md
@@ -15,6 +15,7 @@ Qwen-Agent is a powerful and flexible framework for building intelligent LLM-pow
   Includes versatile tools out of the box:
   - `code_interpreter`: Execute Python code
   - `web_search` and `web_extractor`: Perform web searches and extract page content
+  - `xquik_tweet_search`: Search public X posts with cursor pagination
   - `image_search`: Perform image searches with image
   - `image_zoom_in_tool`: Zoom in on a specific region of an image by cropping it based on a bounding box
 

--- a/qwen_agent/tools/__init__.py
+++ b/qwen_agent/tools/__init__.py
@@ -1,11 +1,11 @@
 # Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,16 +18,17 @@ from .code_interpreter import CodeInterpreter
 from .doc_parser import DocParser
 from .extract_doc_vocabulary import ExtractDocVocabulary
 from .image_gen import ImageGen
+from .image_search import ImageSearch
+from .image_zoom_in_qwen3vl import ImageZoomInToolQwen3VL
+from .mcp_manager import MCPManager
 from .python_executor import PythonExecutor
 from .retrieval import Retrieval
-from .image_zoom_in_qwen3vl import ImageZoomInToolQwen3VL
-from .image_search import ImageSearch
 from .search_tools import FrontPageSearch, HybridSearch, KeywordSearch, VectorSearch
 from .simple_doc_parser import SimpleDocParser
 from .storage import Storage
 from .web_extractor import WebExtractor
-from .mcp_manager import MCPManager
 from .web_search import WebSearch
+from .xquik_tweet_search import XquikTweetSearch
 
 __all__ = [
     'BaseTool',
@@ -50,4 +51,5 @@ __all__ = [
     'PythonExecutor',
     'MCPManager',
     'WebSearch',
+    'XquikTweetSearch',
 ]

--- a/qwen_agent/tools/web_search.py
+++ b/qwen_agent/tools/web_search.py
@@ -1,11 +1,11 @@
 # Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@ from qwen_agent.tools.base import BaseTool, register_tool
 
 SERPER_API_KEY = os.getenv('SERPER_API_KEY', '')
 SERPER_URL = os.getenv('SERPER_URL', 'https://google.serper.dev/search')
+DEFAULT_WEB_SEARCH_TIMEOUT = 30
 
 
 @register_tool('web_search', allow_overwrite=True)
@@ -53,7 +54,12 @@ class WebSearch(BaseTool):
             )
         headers = {'Content-Type': 'application/json', 'X-API-KEY': SERPER_API_KEY}
         payload = {'q': query}
-        response = requests.post(SERPER_URL, json=payload, headers=headers)
+        response = requests.post(
+            SERPER_URL,
+            json=payload,
+            headers=headers,
+            timeout=DEFAULT_WEB_SEARCH_TIMEOUT,
+        )
         response.raise_for_status()
 
         return response.json()['organic']

--- a/qwen_agent/tools/xquik_tweet_search.py
+++ b/qwen_agent/tools/xquik_tweet_search.py
@@ -1,0 +1,121 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from typing import Any, Dict, Optional, Union
+
+import requests
+
+from qwen_agent.tools.base import BaseTool, register_tool
+
+DEFAULT_XQUIK_BASE_URL = 'https://xquik.com'
+DEFAULT_XQUIK_TIMEOUT = 30
+XQUIK_API_CONTRACT = '2026-04-29'
+XQUIK_TWEET_SEARCH_PATH = '/api/v1/x/tweets/search'
+
+
+@register_tool('xquik_tweet_search', allow_overwrite=True)
+class XquikTweetSearch(BaseTool):
+    name = 'xquik_tweet_search'
+    description = 'Search public X posts through Xquik.'
+    parameters = {
+        'type': 'object',
+        'properties': {
+            'query': {
+                'type': 'string',
+                'description': 'Keyword, post ID, X status URL, or X search query.',
+            },
+            'query_type': {
+                'type': 'string',
+                'description': 'Return chronological Latest results or engagement-ranked Top results.',
+                'enum': ['Latest', 'Top'],
+            },
+            'limit': {
+                'type': 'integer',
+                'description': 'Maximum number of posts to return.',
+                'minimum': 1,
+                'maximum': 200,
+            },
+            'cursor': {
+                'type': 'string',
+                'description': 'Opaque pagination cursor from a previous response.',
+            },
+            'since_time': {
+                'type': 'integer',
+                'description': 'Unix timestamp in seconds for the start of the search window.',
+            },
+            'until_time': {
+                'type': 'integer',
+                'description': 'Unix timestamp in seconds for the end of the search window.',
+            },
+        },
+        'required': ['query'],
+    }
+
+    def __init__(self, cfg: Optional[Dict[str, Any]] = None):
+        super().__init__(cfg)
+        self.api_key = self.cfg.get('api_key') or os.getenv('XQUIK_API_KEY', '')
+        self.base_url = (self.cfg.get('base_url') or os.getenv('XQUIK_BASE_URL', DEFAULT_XQUIK_BASE_URL)).rstrip('/')
+        self.timeout = self.cfg.get('timeout', DEFAULT_XQUIK_TIMEOUT)
+        if isinstance(self.timeout, bool) or not isinstance(self.timeout, (int, float)) or self.timeout <= 0:
+            raise ValueError('timeout must be a positive number.')
+
+    def call(self, params: Union[str, dict], **kwargs) -> str:
+        params = self._verify_json_format_args(params)
+        query = params['query'].strip()
+        if not query:
+            raise ValueError('query must not be empty.')
+
+        request_params: Dict[str, Any] = {'q': query}
+        self._copy_optional_param(params, request_params, 'query_type', 'queryType')
+        self._copy_optional_param(params, request_params, 'limit')
+        self._copy_optional_param(params, request_params, 'cursor')
+        self._copy_optional_param(params, request_params, 'since_time', 'sinceTime')
+        self._copy_optional_param(params, request_params, 'until_time', 'untilTime')
+
+        return self._format_response(self._get(request_params))
+
+    @staticmethod
+    def _copy_optional_param(source: dict, target: Dict[str, Any], source_key: str, target_key: Optional[str] = None):
+        value = source.get(source_key)
+        if value is not None and value != '':
+            target[target_key or source_key] = value
+
+    def _get(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if not self.api_key:
+            raise ValueError('XQUIK_API_KEY is required to use xquik_tweet_search.')
+
+        response = requests.get(
+            f'{self.base_url}{XQUIK_TWEET_SEARCH_PATH}',
+            headers={
+                'Accept': 'application/json',
+                'x-api-key': self.api_key,
+                'xquik-api-contract': XQUIK_API_CONTRACT,
+            },
+            params=params,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise ValueError('Xquik returned an unexpected response contract.')
+        return payload
+
+    @staticmethod
+    def _format_response(response: Dict[str, Any]) -> str:
+        if (not isinstance(response.get('tweets'), list) or not isinstance(response.get('has_more'), bool) or
+                not isinstance(response.get('next_cursor'), str)):
+            raise ValueError('Xquik returned an unexpected response contract.')
+        return json.dumps(response, ensure_ascii=False)

--- a/tests/tools/test_web_search.py
+++ b/tests/tools/test_web_search.py
@@ -1,0 +1,54 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import qwen_agent.tools.web_search as web_search_module
+from qwen_agent.tools.web_search import DEFAULT_WEB_SEARCH_TIMEOUT, WebSearch
+
+
+class MockResponse:
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return {'organic': [{'title': 'Qwen-Agent'}]}
+
+
+def test_web_search_uses_bounded_timeout(monkeypatch):
+    calls = []
+
+    def mock_post(url, json, headers, timeout):
+        calls.append({
+            'url': url,
+            'json': json,
+            'headers': headers,
+            'timeout': timeout,
+        })
+        return MockResponse()
+
+    monkeypatch.setattr(web_search_module, 'SERPER_API_KEY', 'test-key')
+    monkeypatch.setattr(web_search_module.requests, 'post', mock_post)
+
+    assert WebSearch.search('agent framework') == [{'title': 'Qwen-Agent'}]
+    assert calls == [{
+        'url': web_search_module.SERPER_URL,
+        'json': {
+            'q': 'agent framework',
+        },
+        'headers': {
+            'Content-Type': 'application/json',
+            'X-API-KEY': 'test-key',
+        },
+        'timeout': DEFAULT_WEB_SEARCH_TIMEOUT,
+    }]

--- a/tests/tools/test_xquik_tweet_search.py
+++ b/tests/tools/test_xquik_tweet_search.py
@@ -1,0 +1,146 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+from qwen_agent.tools import XquikTweetSearch
+from qwen_agent.tools.xquik_tweet_search import XQUIK_API_CONTRACT, XQUIK_TWEET_SEARCH_PATH
+
+
+class MockResponse:
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+def test_xquik_tweet_search_requests_normalized_contract(monkeypatch):
+    calls = []
+    payload = {
+        'tweets': [{
+            'id': '123',
+            'text': 'Qwen-Agent with X search',
+            'created': 1782648000,
+            'url': 'https://x.com/qwen/status/123',
+            'lang': 'en',
+            'like_count': 7,
+            'bookmark_count': 2,
+            'author': {
+                'id': '456',
+                'username': 'qwen',
+                'name': 'Qwen',
+            },
+        }],
+        'has_more': True,
+        'next_cursor': 'cursor-2',
+    }
+
+    def mock_get(url, headers, params, timeout):
+        calls.append({
+            'url': url,
+            'headers': headers,
+            'params': params,
+            'timeout': timeout,
+        })
+        return MockResponse(payload)
+
+    monkeypatch.setattr('qwen_agent.tools.xquik_tweet_search.requests.get', mock_get)
+    tool = XquikTweetSearch({
+        'api_key': 'test-key',
+        'base_url': 'https://example.com/',
+        'timeout': 10,
+    })
+
+    result = json.loads(
+        tool.call({
+            'query': ' agent framework ',
+            'query_type': 'Latest',
+            'limit': 5,
+            'cursor': 'cursor-1',
+            'since_time': 1782600000,
+            'until_time': 1782686400,
+        }))
+
+    assert calls == [{
+        'url': f'https://example.com{XQUIK_TWEET_SEARCH_PATH}',
+        'headers': {
+            'Accept': 'application/json',
+            'x-api-key': 'test-key',
+            'xquik-api-contract': XQUIK_API_CONTRACT,
+        },
+        'params': {
+            'q': 'agent framework',
+            'queryType': 'Latest',
+            'limit': 5,
+            'cursor': 'cursor-1',
+            'sinceTime': 1782600000,
+            'untilTime': 1782686400,
+        },
+        'timeout': 10,
+    }]
+    assert result == payload
+
+
+def test_xquik_tweet_search_requires_api_key(monkeypatch):
+    monkeypatch.delenv('XQUIK_API_KEY', raising=False)
+    tool = XquikTweetSearch()
+
+    with pytest.raises(ValueError, match='XQUIK_API_KEY'):
+        tool.call({'query': 'agent framework'})
+
+
+def test_xquik_tweet_search_rejects_empty_query():
+    tool = XquikTweetSearch({'api_key': 'test-key'})
+
+    with pytest.raises(ValueError, match='query must not be empty'):
+        tool.call({'query': ' '})
+
+
+@pytest.mark.parametrize(
+    'payload',
+    [
+        [],
+        {
+            'tweets': [],
+            'has_more': 'yes',
+            'next_cursor': '',
+        },
+        {
+            'tweets': [],
+            'has_more': False,
+        },
+    ],
+)
+def test_xquik_tweet_search_rejects_unexpected_response(payload, monkeypatch):
+    monkeypatch.setattr(
+        'qwen_agent.tools.xquik_tweet_search.requests.get',
+        lambda *args, **kwargs: MockResponse(payload),
+    )
+    tool = XquikTweetSearch({'api_key': 'test-key'})
+
+    with pytest.raises(ValueError, match='unexpected response contract'):
+        tool.call({'query': 'agent framework'})
+
+
+@pytest.mark.parametrize('timeout', [0, -1, True, '30'])
+def test_xquik_tweet_search_rejects_invalid_timeout(timeout):
+    with pytest.raises(ValueError, match='timeout must be a positive number'):
+        XquikTweetSearch({'api_key': 'test-key', 'timeout': timeout})


### PR DESCRIPTION
## Summary

- Bound the existing `web_search` HTTP request with a 30-second timeout.
- Add a built-in, read-only `xquik_tweet_search` tool.
- Export the tool and document its environment setup and pagination contract.
- Add offline regression coverage for both changes.

## Independent repository fix

The existing `web_search` request had no timeout. A stalled search service could therefore block an agent run indefinitely. The first commit adds a bounded timeout and a regression test that verifies every request uses it.

Upstream evidence: https://github.com/QwenLM/Qwen-Agent/blob/31a4d36d123688581a9e9744427272b33ce940e0/qwen_agent/tools/web_search.py#L54-L57

## Xquik integration

- Uses `GET /api/v1/x/tweets/search` with `x-api-key` authentication.
- Requests the normalized `2026-04-29` response contract explicitly.
- Supports Latest or Top results, limits up to 200, opaque cursors, and time windows.
- Preserves the complete normalized response, including `tweets`, `has_more`, and `next_cursor`.
- Rejects missing credentials, empty queries, invalid timeouts, and malformed response contracts.
- Documents configuration, pagination, official API guidance, and service independence.

## Validation

- `.venv/bin/pre-commit run --from-ref upstream/main --to-ref HEAD`
- `.venv/bin/python -m pytest tests/tools/test_web_search.py tests/tools/test_xquik_tweet_search.py -q` (`11 passed`)
- `.venv/bin/python -m compileall -q qwen_agent tests/tools/test_web_search.py tests/tools/test_xquik_tweet_search.py`
- Tool registry import check
- Wheel build and module inclusion check
- `npm ci && npm run build` in `qwen-agent-docs/website`
- `git diff --check upstream/main...HEAD`

The documentation build passes. `npm ci` reports existing dependency audit findings; this PR does not change the JavaScript dependency graph or lockfile.
