### PR TITLE
Add MiniMax-M3 to DeepPlanning model config

### DIFF
--- a/benchmark/deepplanning/models_config.json
+++ b/benchmark/deepplanning/models_config.json
@@ -30,6 +30,13 @@
       "extra_body": {
         "reasoning_effort": "high"
       }
+    },
+    "MiniMax-M3": {
+      "model_name": "MiniMax-M3",
+      "model_type": "openai",
+      "base_url": "https://api.minimax.io/v1",
+      "api_key_env": "MINIMAX_API_KEY",
+      "temperature": 0.0
     }
   }
 }


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax-M3 to the DeepPlanning OpenAI-compatible model configuration.
- Use the MiniMax global OpenAI-compatible base URL and MINIMAX_API_KEY environment variable.

## Test plan
- python3 -m json.tool benchmark/deepplanning/models_config.json
- Secret scan command from worker instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)