### PR TITLE
fix: use tool_call_id (not id) for tool-role messages in _conv_qwen_agent_messages_to_oai

### DIFF
--- a/qwen_agent/llm/base.py
+++ b/qwen_agent/llm/base.py
@@ -443,7 +443,7 @@ class BaseChatModel(ABC):
             elif msg['role'] == FUNCTION:
                 new_msg = copy.deepcopy(msg)
                 new_msg['role'] = 'tool'
-                new_msg['id'] = msg.get('extra', {}).get('function_id', '1')
+                new_msg['tool_call_id'] = msg.get('extra', {}).get('function_id', '1')
                 new_messages.append(new_msg)
             else:
                 new_messages.append(msg)


### PR DESCRIPTION
## Summary

`BaseChatModel._conv_qwen_agent_messages_to_oai` converts Qwen-Agent messages into the OpenAI-style message list that is sent to OpenAI-compatible endpoints (`oai`, `qwenvl_oai`) and to DashScope (`qwen_dashscope`, `qwenvl_dashscope`) when `use_raw_api=True`.

For a tool result (role `function`), it set the field **`id`** on the resulting `role="tool"` message:

```python
elif msg['role'] == FUNCTION:
    new_msg = copy.deepcopy(msg)
    new_msg['role'] = 'tool'
    new_msg['id'] = msg.get('extra', {}).get('function_id', '1')   # <-- wrong field
    new_messages.append(new_msg)
```

The OpenAI Chat Completions API and the DashScope API both require the field **`tool_call_id`** on `role="tool"` messages so the tool result can be linked back to the assistant's `tool_call`. `id` is not a recognized field, so the tool result is not matched to its call (and OpenAI-compatible servers reject the request).

This affects **multi-turn function calling through the native tool-call API** (`use_raw_api=True`), which is now the default for `qwen_dashscope` models (see `BaseChatModel.__init__`).

## Fix

Set `tool_call_id` instead of `id`. The assistant's `tool_calls[].id` is already populated from `function_id` a few lines above, so the tool result now references the same value via the correct field — consistent with the repo's own benchmark agents (e.g. `benchmark/deepplanning/travelplanning/agent/tools_fn_agent.py`, which appends `{"role": "tool", "tool_call_id": ..., "name": ..., "content": ...}`).

One-line change; no behavior change for the prompt-based function-calling path (which never produces `role="tool"` messages here).
