### PR TITLE
fix(group_chat): dedup @-mentions by agent name, not agent object

### DIFF
--- a/qwen_agent/agents/group_chat.py
+++ b/qwen_agent/agents/group_chat.py
@@ -127,7 +127,7 @@ class GroupChat(Agent, MultiAgentHub):
                 for x in content.split('@'):
                     for agent in self.agents:
                         if x.startswith(agent.name):
-                            if agent not in mentioned_agents_name:
+                            if agent.name not in mentioned_agents_name:
                                 mentioned_agents_name.append(agent.name)
                             break
             rsp = []


### PR DESCRIPTION
### Summary

In `GroupChat._gen_batch_response`, the code that records `@`-mentioned speakers checks membership against the wrong type, so its de-duplication guard never triggers.

```python
# qwen_agent/agents/group_chat.py
mentioned_agents_name = mentioned_agents_name or []   # list of NAME strings
...
for x in content.split('@'):
    for agent in self.agents:                          # agent is an Agent object
        if x.startswith(agent.name):
            if agent not in mentioned_agents_name:     # <-- object vs. list of strings
                mentioned_agents_name.append(agent.name)
            break
```

`self.agents` is a `List[Agent]` (objects), while `mentioned_agents_name` holds agent **names** (strings) — it is populated with `agent.name` and consumed elsewhere as a name (`agents_map[mentioned_agents_name[0]]` in `_select_agent`, and `assert rsp[-1].name == mentioned_agents_name[0]`). Since an `Agent` instance never equals a name string, `agent not in mentioned_agents_name` is always `True`, so the guard is a no-op.

### Impact

The mention queue can contain the same agent multiple times. For example a single user turn like `@Bob help, and @Bob what do you think?`, or a name that is already queued from a previous round, causes that agent to be appended again and therefore to speak multiple times, consuming rounds and distorting the intended speaking order. The duplicate-prevention that the `if ... not in ...` guard was written to provide does not work.

### Fix

Compare the agent **name** against the list of names, matching how the list is built and used everywhere else:

```python
if agent.name not in mentioned_agents_name:
    mentioned_agents_name.append(agent.name)
```

One-line change; behavior is unchanged except that a given agent name is now queued at most once.

### Verification

- Reproduced the exact guard logic in isolation: the current code yields `['Tou Da', 'Tou Da']` for both an intra-message double mention and an already-queued name, while the fixed expression yields `['Tou Da']`.
- Ran `python -m py_compile` on the modified `qwen_agent/agents/group_chat.py` (passes).
- Full test suite not executed (requires model/service credentials and optional deps).
