### PR TITLE
Fix contains_html_tags false positives (broken tag-detection regex)

### DIFF
--- a/qwen_agent/utils/utils.py
+++ b/qwen_agent/utils/utils.py
@@ -226,7 +226,10 @@ def read_text_from_file(path: str) -> str:
 
 
 def contains_html_tags(text: str) -> bool:
-    pattern = r'<(p|span|div|li|html|script)[^>]*?'
+    # Match an HTML tag start followed by a valid tag delimiter (whitespace, '/', or '>').
+    # The delimiter avoids false positives on plain text such as ``vector<pair<int>>`` or
+    # ``a<div_b`` where the tag name is only part of a longer word.
+    pattern = r'<(?:p|span|div|li|html|script)(?:\s|/|>)'
     return bool(re.search(pattern, text))
 
 


### PR DESCRIPTION
## What

`qwen_agent/utils/utils.py::contains_html_tags` is used by `get_file_type()` to decide whether a local, extension-less or `.txt` file is HTML (parsed via BeautifulSoup) or plain text. The current detection regex is broken:

    pattern = r'<(p|span|div|li|html|script)[^>]*?'

The trailing `[^>]*?` is a lazy zero-or-more quantifier with nothing after it, so it always matches the empty string and is dead code. The effective pattern is just `<(p|span|div|li|html|script)`, which matches the tag name even when it is only part of a longer word rather than a real tag start. As a result plain text or code such as `vector<pair<int>>`, `temperature <point five`, `a<div_b`, or `<listing` is misclassified as HTML.

When a plain `.txt` file is misclassified, `get_file_type` returns `html` and the file is run through `BeautifulSoup(...).get_text()`, which silently strips the `<...>`-looking substrings and corrupts the ingested RAG content, e.g.:

    before: 'The template std::vector<pair<int,int>> stores pairs.'
    after : 'The template std::vector> stores pairs.'

## Fix

Require the tag name to be followed by a valid tag delimiter (whitespace, `/`, or `>`), which is how every real HTML opening tag is written:

    pattern = r'<(?:p|span|div|li|html|script)(?:\s|/|>)'

Real opening tags (`<div>`, `<div class="x">`, `<script src="a.js">`, `<li>`, `<html lang="en">`, `<div/>`) are still detected; plain-text/code substrings no longer produce false positives.

## Verification

Checked against 15 cases (8 real HTML fragments, 7 plain-text/code strings): the old regex is wrong on 5/15 (all false positives on plain text/code); the new regex is correct on 15/15. `python -m py_compile` passes on the changed file.

Verification status: pure-function behavior verified by direct execution; full test suite not run (RAG optional deps not installed).
