### PR TITLE
fix(deepplanning): temperature=0.0 is silently dropped by truthiness check

### DIFF
--- a/benchmark/deepplanning/shoppingplanning/agent/call_llm.py
+++ b/benchmark/deepplanning/shoppingplanning/agent/call_llm.py
@@ -139,7 +139,7 @@ def call_llm(
             if tools:
                 params["tools"] = tools
             
-            if not is_reasoning_model and temperature:
+            if not is_reasoning_model and temperature is not None:
                 params["temperature"] = temperature
             
             if extra_body:

--- a/benchmark/deepplanning/travelplanning/agent/call_llm.py
+++ b/benchmark/deepplanning/travelplanning/agent/call_llm.py
@@ -145,7 +145,7 @@ def call_llm(
             if tools:
                 params["tools"] = tools
             
-            if not is_reasoning_model and temperature:
+            if not is_reasoning_model and temperature is not None:
                 params["temperature"] = temperature
             
             if extra_body:


### PR DESCRIPTION
### Problem

In both copies of `call_llm.py` (travelplanning and shoppingplanning), the temperature parameter is gated by a truthiness check:

```python
if not is_reasoning_model and temperature:
    params["temperature"] = temperature
```

`0.0` is falsy in Python, so a temperature explicitly configured as `0.0` in `models_config.json` is silently dropped — the request is sent **without** a `temperature` field, and the provider applies its own default (typically 0.7–1.0).

### Impact

Any DeepPlanning evaluation configured with `temperature: 0.0` for deterministic (greedy) decoding has actually been running with provider-default sampling. This affects reproducibility of reported results: score variance and degenerate-repetition behavior observed "at temperature 0" may partly be sampling artifacts.

We noticed this while benchmarking on travelplanning: with `temperature: 0.0` configured, request payloads contained no `temperature` field; after forcing `temperature: 0.0` through (via `extra_body` as a workaround), repeated runs of the same case produced byte-identical tool calls for the initial rounds, confirming the parameter had not been applied before.

### Fix

```python
if not is_reasoning_model and temperature is not None:
```

An explicit `0.0` is now sent, while an unset config value still omits the parameter (preserving the original intent). Same one-line change applied to both `travelplanning/agent/call_llm.py` and `shoppingplanning/agent/call_llm.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6Yq3xUud5mxV7xKhDsnT3