### PR TITLE
Fix DocParser crash when chunk overlap fills the whole page-size budget

### DIFF
--- a/qwen_agent/tools/doc_parser.py
+++ b/qwen_agent/tools/doc_parser.py
@@ -192,10 +192,14 @@ class DocParser(BaseTool):
 
                         # Define new chunk
                         overlap_txt = self._get_last_part(chunk)
-                        if overlap_txt.strip():
+                        overlap_token = count_tokens(overlap_txt)
+                        # Drop the overlap when it would fill the whole chunk, otherwise
+                        # available_token becomes 0 and splitting a long paragraph below hits
+                        # range(..., 0) -> ValueError.
+                        if overlap_txt.strip() and overlap_token < parser_page_size:
                             chunk = [f'[page: {str(chunk[-1][1])}]', overlap_txt]
                             has_para = False
-                            available_token = parser_page_size - count_tokens(overlap_txt)
+                            available_token = parser_page_size - overlap_token
                         else:
                             chunk = []
                             has_para = False
@@ -248,10 +252,11 @@ class DocParser(BaseTool):
                                           token=parser_page_size - available_token))
 
                                 overlap_txt = self._get_last_part(chunk)
-                                if overlap_txt.strip():
+                                overlap_token = count_tokens(overlap_txt)
+                                if overlap_txt.strip() and overlap_token < parser_page_size:
                                     chunk = [f'[page: {str(chunk[-1][1])}]', overlap_txt]
                                     has_para = False
-                                    available_token = parser_page_size - count_tokens(overlap_txt)
+                                    available_token = parser_page_size - overlap_token
                                 else:
                                     chunk = []
                                     has_para = False

--- a/tests/tools/test_doc_parser.py
+++ b/tests/tools/test_doc_parser.py
@@ -13,12 +13,36 @@
 # limitations under the License.
 
 from qwen_agent.tools import DocParser
+from qwen_agent.utils.tokenization_qwen import count_tokens
 
 
 def test_doc_parser():
     tool = DocParser()
     res = tool.call({'url': 'https://qianwen-res.oss-cn-beijing.aliyuncs.com/QWEN_TECHNICAL_REPORT.pdf'})
     print(res)
+
+
+def test_split_doc_to_chunk_long_paragraph_small_page_size():
+    # A paragraph that exactly fills the chunk budget, followed by a long paragraph
+    # without sentence delimiters, used to leave available_token == 0 and raise
+    # "ValueError: range() arg 3 must not be zero" while splitting the long paragraph.
+    parser = DocParser()
+    for page_size in [32, 64, 100, 128, 150, 256]:
+        head = '中' * page_size
+        body = '文' * 3000
+        doc = [{
+            'page_num': 0,
+            'content': [
+                {'text': head, 'token': count_tokens(head)},
+                {'text': body, 'token': count_tokens(body)},
+            ],
+        }]
+        chunks = parser.split_doc_to_chunk(doc, path='doc', parser_page_size=page_size)
+        assert chunks, f'no chunks produced for page_size={page_size}'
+        # No content should be lost while chunking.
+        joined = ''.join(chunk.content for chunk in chunks)
+        assert joined.count('中') >= page_size
+        assert joined.count('文') >= 3000
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When the carried-over chunk overlap consumes the entire `parser_page_size` budget, `available_token` becomes 0, so splitting a following long, delimiter-free paragraph hits `range(0, len(token_list), 0)` and raises `ValueError: range() arg 3 must not be zero` (`doc_parser.py:217`).

This is reachable on a valid document with a small non-default `parser_page_size` (e.g. 100–256) and CJK text (≈1 token per character), where the ~150-char overlap can equal or exceed the page-size budget. It does not occur at the default `parser_page_size=500`.

Drop the overlap when it would fill the whole budget, so `available_token` stays > 0 (both overlap sites). Adds a regression test across several page sizes that reproduces the crash and asserts no content is dropped.
