### PR TITLE
feat(agent): auto-load system_prompt_files into system_message

### DIFF
--- a/qwen_agent/agent.py
+++ b/qwen_agent/agent.py
@@ -25,7 +25,7 @@ from qwen_agent.log import logger
 from qwen_agent.tools import TOOL_REGISTRY, BaseTool, MCPManager
 from qwen_agent.tools.base import ToolServiceError
 from qwen_agent.tools.simple_doc_parser import DocParserError
-from qwen_agent.utils.utils import has_chinese_messages, merge_generate_cfgs
+from qwen_agent.utils.utils import has_chinese_messages, merge_generate_cfgs, read_text_from_file
 
 
 class Agent(ABC):
@@ -41,6 +41,7 @@ class Agent(ABC):
                  system_message: Optional[str] = DEFAULT_SYSTEM_MESSAGE,
                  name: Optional[str] = None,
                  description: Optional[str] = None,
+                 system_prompt_files: Optional[List[str]] = None,
                  **kwargs):
         """Initialization the agent.
 
@@ -52,6 +53,9 @@ class Agent(ABC):
             system_message: The specified system message for LLM chat.
             name: The name of this agent.
             description: The description of this agent, which will be used for multi_agent.
+            system_prompt_files: Optional paths to text files (e.g. AGENTS.md / SOUL.md) whose
+              contents are loaded and prepended to `system_message` at init time. Missing files
+              log a warning and are skipped. Also accepted via kwargs for config-driven setup.
         """
         if isinstance(llm, dict):
             self.llm = get_chat_model(llm)
@@ -64,9 +68,44 @@ class Agent(ABC):
             for tool in function_list:
                 self._init_tool(tool)
 
-        self.system_message = system_message
+        # Config/workspace files may pass system_prompt_files via kwargs.
+        if system_prompt_files is None:
+            system_prompt_files = kwargs.get('system_prompt_files')
+        self.system_message = self._load_system_message_with_prompt_files(
+            system_message, system_prompt_files)
         self.name = name
         self.description = description
+
+    @staticmethod
+    def _load_system_message_with_prompt_files(
+            system_message: Optional[str],
+            system_prompt_files: Optional[List[str]]) -> Optional[str]:
+        """Prepend contents of system_prompt_files to the base system_message.
+
+        Files are read in order. Missing or unreadable files warn and are skipped so
+        agent startup is not blocked by an absent workspace file.
+        """
+        parts: List[str] = []
+        if system_prompt_files:
+            for path in system_prompt_files:
+                if not path:
+                    continue
+                try:
+                    text = read_text_from_file(str(path)).strip()
+                except FileNotFoundError:
+                    logger.warning('system_prompt_files: file not found: %s', path)
+                    continue
+                except Exception as ex:  # noqa: BLE001 - surface path and continue
+                    logger.warning('system_prompt_files: failed to read %s: %s', path, ex)
+                    continue
+                if text:
+                    parts.append(text)
+        base = (system_message or '').strip()
+        if base:
+            parts.append(base)
+        if not parts:
+            return system_message
+        return '\n\n'.join(parts)
 
     def run_nonstream(self, messages: List[Union[Dict, Message]], **kwargs) -> Union[List[Message], List[Dict]]:
         """Same as self.run, but with stream=False,

--- a/tests/agents/test_system_prompt_files.py
+++ b/tests/agents/test_system_prompt_files.py
@@ -1,0 +1,69 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+import os
+import tempfile
+
+from qwen_agent.agent import Agent
+from qwen_agent.llm.schema import Message
+
+
+class _DummyAgent(Agent):
+    """Minimal concrete Agent for unit tests (no LLM calls)."""
+
+    def _run(self, messages, lang: str = 'en', **kwargs):
+        yield messages
+
+
+def test_system_prompt_files_prepended_to_system_message(tmp_path):
+    agents_md = tmp_path / 'AGENTS.md'
+    soul_md = tmp_path / 'SOUL.md'
+    agents_md.write_text('You are a careful coding agent.', encoding='utf-8')
+    soul_md.write_text('Your name is Qwen.', encoding='utf-8')
+
+    bot = _DummyAgent(
+        system_message='Base system message.',
+        system_prompt_files=[str(agents_md), str(soul_md)],
+        llm=None,
+    )
+
+    assert 'You are a careful coding agent.' in bot.system_message
+    assert 'Your name is Qwen.' in bot.system_message
+    assert bot.system_message.endswith('Base system message.')
+    # files come first, in order
+    assert bot.system_message.index('careful coding agent') < bot.system_message.index('Your name is Qwen')
+    assert bot.system_message.index('Your name is Qwen') < bot.system_message.index('Base system message')
+
+
+def test_system_prompt_files_via_kwargs(tmp_path):
+    f = tmp_path / 'PROFILE.md'
+    f.write_text('Profile: research assistant', encoding='utf-8')
+    # kwargs path is used when the named param is omitted (config-driven setup).
+    bot = _DummyAgent(system_message='Hi', llm=None, **{'system_prompt_files': [str(f)]})
+    assert 'Profile: research assistant' in bot.system_message
+    assert bot.system_message.endswith('Hi')
+
+
+def test_missing_system_prompt_file_is_skipped(tmp_path):
+    existing = tmp_path / 'AGENTS.md'
+    existing.write_text('Present rules', encoding='utf-8')
+    missing = tmp_path / 'MISSING.md'
+    bot = _DummyAgent(
+        system_message='Base',
+        system_prompt_files=[str(missing), str(existing)],
+        llm=None,
+    )
+    assert 'Present rules' in bot.system_message
+    assert 'Base' in bot.system_message
+    assert 'MISSING' not in bot.system_message
+
+
+def test_run_injects_combined_system_message(tmp_path):
+    f = tmp_path / 'AGENTS.md'
+    f.write_text('Always cite sources.', encoding='utf-8')
+    bot = _DummyAgent(system_message='Be concise.', system_prompt_files=[str(f)], llm=None)
+    *_, last = bot.run([Message('user', 'hello')])
+    assert last[0].role == 'system'
+    assert 'Always cite sources.' in last[0].content
+    assert 'Be concise.' in last[0].content


### PR DESCRIPTION
## Summary
- Add `system_prompt_files` to `Agent.__init__` so workspace prompt files (e.g. `AGENTS.md`, `SOUL.md`, `PROFILE.md`) are loaded at init and prepended to `system_message`.
- Missing/unreadable files log a warning and are skipped (startup is not blocked).
- Also accept `system_prompt_files` via kwargs for config-driven setup.
- Unit tests cover ordering, kwargs, missing files, and injection into `run()`.

Fixes #867

## Test plan
- [x] `pytest tests/agents/test_system_prompt_files.py -q` → **4 passed**
- [ ] Manual: construct an Agent with `system_prompt_files=["AGENTS.md"]` and confirm the system message includes file contents
