### PR TITLE
fix(utils): block SSRF to private addresses in save_url_to_local_work_dir (#913)

### DIFF
--- a/qwen_agent/utils/utils.py
+++ b/qwen_agent/utils/utils.py
@@ -15,6 +15,7 @@
 import base64
 import copy
 import hashlib
+import ipaddress
 import json
 import os
 import re
@@ -181,6 +182,42 @@ def sanitize_windows_file_path(file_path: str) -> str:
     return file_path
 
 
+_ALLOW_PRIVATE_URL_ENV = 'QWEN_AGENT_ALLOW_PRIVATE_URL'
+_MAX_URL_REDIRECTS = 5
+
+
+def _resolves_to_private_address(host: str) -> bool:
+    try:
+        addr_infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        # Let requests report the resolution failure with its own message.
+        return False
+    return any(not ipaddress.ip_address(info[4][0]).is_global for info in addr_infos)
+
+
+def _assert_downloadable_url(url: str) -> None:
+    """Reject URLs that resolve to loopback, private, or link-local addresses (SSRF)."""
+    if os.getenv(_ALLOW_PRIVATE_URL_ENV, '').strip().lower() in ('1', 'true', 'yes'):
+        return
+    host = urllib.parse.urlparse(url).hostname
+    if host and _resolves_to_private_address(host):
+        raise ValueError(f'Refusing to download {url}: it resolves to a non-public (private, loopback, or '
+                         f'link-local) address. Set {_ALLOW_PRIVATE_URL_ENV}=1 to allow internal addresses.')
+
+
+def _download_public_url(url: str, headers: dict) -> requests.Response:
+    """Follow redirects manually so that every hop is checked, not just the URL we were given."""
+    for _ in range(_MAX_URL_REDIRECTS + 1):
+        _assert_downloadable_url(url)
+        response = requests.get(url, headers=headers, allow_redirects=False)
+        location = response.headers.get('location')
+        if response.is_redirect and location:
+            url = urllib.parse.urljoin(url, location)
+            continue
+        return response
+    raise ValueError(f'Too many redirects while downloading {url}.')
+
+
 def save_url_to_local_work_dir(url: str, save_dir: str, save_filename: str = '') -> str:
     if not save_filename:
         save_filename = get_basename_from_url(url)
@@ -197,7 +234,7 @@ def save_url_to_local_work_dir(url: str, save_dir: str, save_filename: str = '')
             'User-Agent':
                 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
         }
-        response = requests.get(url, headers=headers)
+        response = _download_public_url(url, headers=headers)
         if response.status_code == 200:
             with open(new_path, 'wb') as file:
                 file.write(response.content)

--- a/tests/utils/test_url_ssrf.py
+++ b/tests/utils/test_url_ssrf.py
@@ -1,0 +1,82 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+
+from qwen_agent.utils import utils
+
+INTERNAL_URLS = [
+    'http://127.0.0.1:9876/internal/secret',
+    'http://localhost:9876/internal/secret',
+    'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+    'http://10.0.0.5/admin',
+    'http://192.168.1.1/admin',
+]
+
+
+def test_internal_urls_are_rejected():
+    os.environ.pop(utils._ALLOW_PRIVATE_URL_ENV, None)
+    with tempfile.TemporaryDirectory() as work_dir:
+        for url in INTERNAL_URLS:
+            try:
+                utils.save_url_to_local_work_dir(url, work_dir)
+            except ValueError as e:
+                assert 'non-public' in str(e), f'{url} was rejected for the wrong reason: {e}'
+            else:
+                raise AssertionError(f'{url} should have been rejected')
+
+
+def test_internal_urls_are_allowed_when_opted_in():
+    os.environ[utils._ALLOW_PRIVATE_URL_ENV] = '1'
+    try:
+        # The guard must not fire; the request itself is expected to fail because nothing is listening.
+        utils._assert_downloadable_url('http://127.0.0.1:9876/internal/secret')
+    finally:
+        os.environ.pop(utils._ALLOW_PRIVATE_URL_ENV, None)
+
+
+def test_redirect_to_internal_address_is_rejected():
+    os.environ.pop(utils._ALLOW_PRIVATE_URL_ENV, None)
+    requested = []
+
+    class _RedirectingResponse:
+
+        def __init__(self, location):
+            self.headers = {'location': location}
+            self.is_redirect = True
+
+    def _fake_get(url, headers=None, allow_redirects=True):
+        requested.append(url)
+        return _RedirectingResponse('http://169.254.169.254/latest/meta-data/')
+
+    original_get = utils.requests.get
+    utils.requests.get = _fake_get
+    try:
+        utils._download_public_url('http://public.example.com/doc.pdf', headers={})
+    except ValueError as e:
+        assert 'non-public' in str(e), f'redirect was rejected for the wrong reason: {e}'
+    else:
+        raise AssertionError('a redirect to the metadata endpoint should have been rejected')
+    finally:
+        utils.requests.get = original_get
+
+    # The redirect target must never be fetched.
+    assert requested == ['http://public.example.com/doc.pdf'], requested
+
+
+if __name__ == '__main__':
+    test_internal_urls_are_rejected()
+    test_internal_urls_are_allowed_when_opted_in()
+    test_redirect_to_internal_address_is_rejected()


### PR DESCRIPTION
Fixes #913.

### The problem

`save_url_to_local_work_dir()` (`qwen_agent/utils/utils.py`) hands the caller-supplied URL straight to `requests.get()`. Nothing checks where it resolves to. `WebExtractor` exposes that URL through its `url` tool parameter and delegates to `SimpleDocParser`, which reaches the same download path for any `http(s)` input, so a model-controlled (or request-controlled) argument turns the host into an SSRF proxy:

```python
from qwen_agent.tools.simple_doc_parser import SimpleDocParser
SimpleDocParser().call({'url': 'http://169.254.169.254/latest/meta-data/iam/security-credentials/'})
```

Both sinks named in the report funnel through this one function, so the check belongs there rather than in each tool.

### The fix

- `_assert_downloadable_url()` resolves the host with `socket.getaddrinfo()` and rejects the request if **any** returned address is not globally routable. Using `ipaddress.ip_address(...).is_global` covers loopback, RFC-1918, link-local (including `169.254.169.254`), CGNAT, multicast, and reserved ranges in one predicate, for IPv4 and IPv6 alike.
- `_download_public_url()` follows redirects manually, re-checking every hop against the same predicate. This matters: with the previous `allow_redirects=True` default, a public URL that answers `302 Location: http://169.254.169.254/...` would already have made the internal request before anything could look at it.
- Name resolution failures are deliberately **not** turned into a rejection — they fall through so `requests` reports the DNS error with its own message, as before.

### Escape hatch

Fetching from `localhost` or a private network is a legitimate setup (a local document server, an internal file share). Setting `QWEN_AGENT_ALLOW_PRIVATE_URL=1` restores the old behaviour, and the rejection message names the variable so users who hit it can find it without reading the source.

### Tests

`tests/utils/test_url_ssrf.py` covers the three cases that matter: internal URLs are rejected (loopback by IP and by name, the metadata endpoint, and two RFC-1918 hosts), the opt-out re-enables them, and a redirect into the metadata endpoint is rejected **and** never fetched. None of them touch the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
