### PR TITLE
fix(server): reject host file paths at the unauthenticated /endpoint (#912)

### DIFF
--- a/qwen_server/database_server.py
+++ b/qwen_server/database_server.py
@@ -16,6 +16,7 @@ import json
 import multiprocessing
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 import jsonlines
 import uvicorn
@@ -31,7 +32,8 @@ except ImportError:
 
 from qwen_agent.log import logger
 from qwen_agent.memory import Memory
-from qwen_agent.utils.utils import get_basename_from_url, get_file_type, get_local_ip, hash_sha256, save_text_to_file
+from qwen_agent.utils.utils import (get_basename_from_url, get_file_type, get_local_ip, hash_sha256,
+                                    sanitize_chrome_file_path, save_text_to_file)
 from qwen_server.schema import GlobalConfig
 from qwen_server.utils import rm_browsing_meta_data, save_browsing_meta_data, save_history
 
@@ -66,6 +68,44 @@ app.mount('/static', StaticFiles(directory=server_config.path.code_interpreter_w
 cache_file_popup_url = os.path.join(server_config.path.work_space_root, 'popup_url.jsonl')
 meta_file = os.path.join(server_config.path.work_space_root, 'meta_data.jsonl')
 history_dir = os.path.join(server_config.path.work_space_root, 'history')
+
+# This endpoint is unauthenticated, so a request url is only allowed to reach the document parser
+# when it is a web page or a file the server itself owns. Anything else is an attempt to make the
+# parser read an arbitrary host file. Local files that the user picked are added by the
+# workstation UI, which calls Memory directly and does not go through this server.
+ALLOWED_URL_SCHEMES = ('http', 'https')
+ALLOWED_LOCAL_ROOTS = (
+    server_config.path.work_space_root,
+    server_config.path.download_root,
+    server_config.path.code_interpreter_ws,
+)
+# Set QWEN_AGENT_ALLOW_LOCAL_FILE_CACHE=true to keep caching local files outside the workspace,
+# such as a 'file:///...' tab opened in the browser. Only do this if the endpoint is unreachable
+# by anyone but you: it lets a caller read any file the server can read.
+ALLOW_LOCAL_FILE_CACHE = os.getenv('QWEN_AGENT_ALLOW_LOCAL_FILE_CACHE', '').strip().lower() in ('1', 'true', 'yes')
+
+
+def is_within_directory(path: str, directory: str) -> bool:
+    try:
+        directory = os.path.realpath(directory)
+        return os.path.commonpath([os.path.realpath(path), directory]) == directory
+    except ValueError:
+        # Raised for e.g. paths on different Windows drives, which are never within the workspace.
+        return False
+
+
+def validate_url(url: str) -> str:
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError('The url must be a non-empty string.')
+    if ALLOW_LOCAL_FILE_CACHE or urlparse(url).scheme.lower() in ALLOWED_URL_SCHEMES:
+        return url
+    # Resolve the same way the parser does, so that the check covers the path that is really read.
+    local_path = sanitize_chrome_file_path(url)
+    if any(is_within_directory(local_path, root) for root in ALLOWED_LOCAL_ROOTS):
+        return url
+    raise ValueError(f'Refusing to read {url}: this endpoint only accepts http(s) urls and files '
+                     'under the server workspace. Set QWEN_AGENT_ALLOW_LOCAL_FILE_CACHE=true to '
+                     'allow caching other local files.')
 
 
 def update_pop_url(url: str):
@@ -120,13 +160,23 @@ async def web_listening(request: Request):
     if msg_type == 'change_checkbox':
         rsp = change_checkbox_state(data['ckid'])
     elif msg_type == 'cache':
+        try:
+            data['url'] = validate_url(data.get('url', ''))
+        except ValueError as ex:
+            logger.warning(str(ex))
+            return JSONResponse(status_code=400, content=str(ex))
         cache_obj = multiprocessing.Process(target=cache_page, kwargs=data)
         cache_obj.start()
         # rsp = cache_data(data, cache_file)
         rsp = 'caching'
     elif msg_type == 'pop_url':
         # What a misleading name! pop_url actually means add_url. pop is referring to the pop_up ui.
-        rsp = update_pop_url(data['url'])
+        try:
+            url = validate_url(data.get('url', ''))
+        except ValueError as ex:
+            logger.warning(str(ex))
+            return JSONResponse(status_code=400, content=str(ex))
+        rsp = update_pop_url(url)
     else:
         raise NotImplementedError
 

--- a/tests/qwen_server/test_database_server.py
+++ b/tests/qwen_server/test_database_server.py
@@ -17,6 +17,8 @@ import os
 import shutil
 from pathlib import Path
 
+import pytest
+
 from qwen_agent.utils.utils import get_basename_from_url, hash_sha256
 from qwen_server.schema import GlobalConfig
 from qwen_server.utils import read_meta_data_by_condition
@@ -58,3 +60,25 @@ def test_database_server():
     update_pop_url(new_url)
     cache_file_popup_url = os.path.join(server_config.path.work_space_root, 'popup_url.jsonl')
     assert os.path.exists(cache_file_popup_url)
+
+
+def test_validate_url_rejects_host_files():
+    server_config_path = Path(__file__).resolve().parent.parent.parent / 'qwen_server/server_config.json'
+    with open(server_config_path, 'r') as f:
+        server_config = GlobalConfig(**json.load(f))
+    os.makedirs(server_config.path.download_root, exist_ok=True)
+
+    from qwen_server.database_server import validate_url
+
+    # Web pages and files the server owns keep working.
+    assert validate_url('https://github.com/QwenLM/Qwen-Agent') == 'https://github.com/QwenLM/Qwen-Agent'
+    workspace_file = os.path.join(server_config.path.download_root, 'cached.txt')
+    with open(workspace_file, 'w', encoding='utf-8') as f:
+        f.write('cached page')
+    assert validate_url(workspace_file) == workspace_file
+
+    # Files outside the workspace are not readable through the unauthenticated endpoint.
+    outside_file = str(Path(__file__).resolve())
+    for url in [outside_file, 'file://' + outside_file, '', os.path.join('workspace', '..', '..', 'secret.txt')]:
+        with pytest.raises(ValueError):
+            validate_url(url)


### PR DESCRIPTION
Fixes #912.

### The problem

`/endpoint` on the database server (port 7866) is unauthenticated, and both url-carrying tasks feed the document parser directly:

- `task=cache` → `cache_page()` → `mem.run([{'file': url}])`
- `task=pop_url` → `popup_url.jsonl` → `assistant_server.set_url()` → `mem.run([{'file': page_url}])`

`SimpleDocParser` resolves any existing local path, classifies it as `txt`, and returns the file contents into the knowledge base. So the reporter's PoC works as described:

```
curl -X POST http://<target>:7866/endpoint \
  -H 'Content-Type: application/json' \
  -d '{"task": "cache", "url": "/etc/passwd"}'
```

`--server_host 0.0.0.0` makes it an unauthenticated remote read of any file the server process can open.

### The fix

Validate the url in the handler, before it reaches `Memory`:

- `http(s)` urls pass — that is all the browser extension ever sends (`background.js` posts `tabs[0].url`).
- Local paths inside `work_space_root` / `download_root` / `code_interpreter_ws` pass — that is what `cache_page()`'s own "map to local url" branch produces and what `pop_url` receives back from it. Containment is checked on the `realpath`, after `sanitize_chrome_file_path()`, so the check covers the path that is really opened rather than the string that was posted.
- Anything else gets a 400 and a log line.

Files the user picks are added by the workstation UI (`add_file()` calls `Memory` directly), so that flow is untouched. For anyone who does rely on caching a `file:///...` tab on a host only they can reach, `QWEN_AGENT_ALLOW_LOCAL_FILE_CACHE=true` restores the previous behavior.

I deliberately did not add the restriction inside `SimpleDocParser`, as the report suggests: passing an absolute local path there is the documented library API (`Assistant(files=[...])`), so restricting the parser would break normal use. The unauthenticated network boundary is the right place for it.

### Verification

Added `test_validate_url_rejects_host_files` to `tests/qwen_server/test_database_server.py`: a web url and a file under `download_root` still pass; a path outside the workspace, its `file://` form, an empty url, and a `..` traversal all raise. The existing `test_database_server` calls `cache_page`/`update_pop_url` directly and is unaffected.

Lint: clean under the pinned pre-commit hooks (flake8 5.0.4, yapf 0.32.0 google/120, isort 5.11.5) apart from the license-header whitespace that already exists on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
