### PR TITLE
docs: add SECURITY.md for coordinated vulnerability disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+The Qwen-Agent team takes security issues seriously and appreciates the effort of researchers and users who report vulnerabilities responsibly.
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, use one of the following private channels so we can validate and fix the issue before it becomes public:
+
+1. **GitHub Security Advisories (preferred).** Open a private report from the [Security tab](https://github.com/QwenLM/Qwen-Agent/security/advisories/new). Only Qwen-Agent maintainers see the report until the advisory is published.
+2. **Email.** If GitHub Security Advisories are not usable for you, contact the Qwen team through the address listed on the [Qwen organization page](https://github.com/QwenLM) or via the community channels linked from the project README (WeChat, Discord).
+
+When reporting, please include as much of the following as you can:
+
+- A clear description of the issue and the affected component (agent, tool, integration, etc.).
+- The version, commit SHA, or release tag where you observed the behavior.
+- Reproduction steps or a minimal proof-of-concept.
+- The impact you believe the issue has (data exposure, code execution, denial of service, etc.).
+- Any suggested remediation, if you have one.
+
+## What to Expect
+
+- **Acknowledgement:** we aim to acknowledge new reports within a few business days.
+- **Triage:** we will work with you to reproduce the issue and confirm its impact.
+- **Fix and disclosure:** for confirmed vulnerabilities we will prepare a fix, coordinate a release, and publish a security advisory. We are happy to credit reporters in the advisory unless they prefer to remain anonymous.
+- **Please give us reasonable time** to investigate and remediate before any public disclosure.
+
+## Scope
+
+This policy covers the code in the `QwenLM/Qwen-Agent` repository. Vulnerabilities in third-party dependencies should generally be reported to the corresponding upstream project; if the exposure is specific to how Qwen-Agent uses that dependency, we still want to hear about it.
+
+Out of scope (unless combined with a concrete impact against Qwen-Agent):
+
+- Reports generated purely from automated scanners without an exploitation path.
+- Findings limited to example code, documentation snippets, or benchmarks intended for local experimentation.
+- Missing security headers on documentation sites, or informational best-practice suggestions.
+
+Thank you for helping keep Qwen-Agent and its users safe.


### PR DESCRIPTION
## What this changes

Adds a `SECURITY.md` at the repository root that points reporters at a private disclosure channel instead of a public GitHub issue.

## Why

Qwen-Agent is widely used (LLM tool layer, code execution sandbox, browser/document loaders) and currently ships without a documented security reporting path. When a researcher notices something sensitive today, the paths they see from the repo homepage are:

- open a public GitHub issue (bad — details become public before a fix)
- comment on an unrelated PR
- ask on Discord / WeChat, where any observer sees the report

A short `SECURITY.md` closes that gap. The file:

- Names GitHub Security Advisories as the preferred private channel (the "Report a vulnerability" button on the [Security tab](https://github.com/QwenLM/Qwen-Agent/security/advisories/new)).
- Lists the existing community channels from the README (WeChat, Discord, the QwenLM org page) as a fallback if the advisory flow does not work for the reporter.
- Describes what a good report should include (component, version/SHA, repro, impact).
- States what a reporter can expect (acknowledgement, triage, fix + advisory, credit).
- Sets a small scope block so the maintainers are not on the hook for pure scanner output or example-code findings.

Nothing in the file commits Qwen-Agent to a new process it doesn't already have — every referenced channel already exists.

## Notes for reviewers

- Only one file is added, at the repository root, which is where GitHub looks for `SECURITY.md` and where the "Security policy" link on the repo landing page resolves.
- No workflow, code, or dependency changes.
- Happy to adjust wording, add a language note (中文), or point at a specific mailing address if the Qwen team would prefer that over GitHub Security Advisories.

## Checklist

- [x] File added at `SECURITY.md` (repo root)
- [x] Markdown renders cleanly on GitHub
- [x] No code changes, no CI impact

Thanks for maintaining Qwen-Agent.
