### PR TITLE
ci: pin deploy-docs actions to SHAs and disable persisted checkout token

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,10 +26,12 @@ jobs:
         working-directory: qwen-agent-docs/website
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '18'
           cache: 'npm'
@@ -44,7 +46,7 @@ jobs:
           NODE_ENV: production
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: qwen-agent-docs/website/out
 
@@ -57,5 +59,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 


### PR DESCRIPTION
## What this changes

Hardens the single GitHub Actions workflow in the repo (`.github/workflows/deploy-docs.yml`, which deploys the docs site to GitHub Pages) with two small, standard changes:

1. Pin every GitHub-hosted action to a full commit SHA (with the version kept as a comment on the same line).
2. Add `persist-credentials: false` to the `actions/checkout` step.

## Diff shape

```yaml
- uses: actions/checkout@v4
+ uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+   with:
+     persist-credentials: false

- uses: actions/setup-node@v4
+ uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

- uses: actions/upload-pages-artifact@v3
+ uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1

- uses: actions/deploy-pages@v4
+ uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
```

Six lines added, four lines removed — one file touched.

## Why pin to SHA

Mutable major-version tags (`@v4`, `@v3`) point at whatever commit the action owner (or, in the worst case, whoever compromises an action release) most recently moved that tag to. The workflow runs on `main` pushes with `id-token: write` and `pages: write`, which is exactly the kind of surface the [tj-actions/changed-files compromise (CVE-2025-30066)](https://github.com/tj-actions/changed-files/security/advisories) exploited: tags were silently repointed at malicious commits, and every consumer using the mutable tag executed that code in privileged CI contexts.

Pinning to a full commit SHA makes the exact code that runs on the docs deploy auditable and immune to silent tag re-pointing. GitHub's own [security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommends this, and it's the default for OpenSSF Scorecard's "Pinned-Dependencies" check.

The version is retained as a trailing comment on each line (`# v4.4.0`) so Dependabot / Renovate can continue to bump the SHAs — no automation is broken by this change.

## Why persist-credentials: false

`actions/checkout` by default writes the workflow's short-lived `GITHUB_TOKEN` into `.git/config` after cloning, so later steps that shell out to `git` can push. This workflow doesn't push anything back to the repo — the `build` job only runs `npm ci` and `npm run build`, then hands the artifact to `actions/deploy-pages`, which uses OIDC (`id-token: write`), not the checkout token. Turning off credential persistence removes the token from disk for the rest of the job. If a downstream `npm` package or build step is ever compromised, it can't read the token from `.git/config` and push commits back to `QwenLM/Qwen-Agent`.

This mirrors the [`actions/checkout` README's own guidance](https://github.com/actions/checkout#usage) and shows up as OpenSSF Scorecard's "Token-Permissions" check.

## What is deliberately not changed

- Job-level `permissions:` are already set correctly (`contents: read`, `pages: write`, `id-token: write`) — no change needed.
- The top-level `permissions:` block is already scoped — no change needed.
- The action versions themselves are held at the current major tips (v4.4.0 / v3.0.1) so behavior is identical.
- The docs source paths, working directory, Node version, and concurrency group are untouched.

## Verification

- Local `yaml.safe_load` on the edited file succeeds.
- Each pinned SHA was resolved from `GET /repos/{owner}/{repo}/git/ref/tags/{tag}` (annotated tags dereferenced to their commit) against the four action repositories, and the SHA is the current tip of the version in the trailing comment.
- The `build` job's steps still run in the same order; no new secrets, tokens, or environment variables are introduced.

## Why this is worth merging

The repo currently has one workflow that runs on pushes to `main` with write scopes for Pages and OIDC. It is small, but it is the one automation surface that has any real blast radius, and hardening it is a ten-line diff that also lets a future OpenSSF Scorecard run pass its two most-cited checks (Pinned-Dependencies, Token-Permissions). It's a good candidate for a first commit because it's low risk and easy to review.

## Checklist

- [x] Only `.github/workflows/deploy-docs.yml` is modified
- [x] YAML validated with `yaml.safe_load`
- [x] Each SHA is the current tip of the tag it replaces
- [x] Version kept as a trailing comment for Dependabot / Renovate
- [x] No functional change to the deploy pipeline

Thanks for maintaining Qwen-Agent.
