### PR TITLE
Add MiniMax-M2.7 to DeepPlanning model config

### DIFF
--- a/benchmark/deepplanning/models_config.json
+++ b/benchmark/deepplanning/models_config.json
@@ -30,7 +30,13 @@
       "extra_body": {
         "reasoning_effort": "high"
       }
+    },
+    "MiniMax-M2.7": {
+      "model_name": "MiniMax-M2.7",
+      "model_type": "openai",
+      "base_url": "https://api.minimax.io/v1",
+      "api_key_env": "MINIMAX_API_KEY",
+      "temperature": 0.0
     }
   }
 }
-


### PR DESCRIPTION
Reason: The DeepPlanning source registry is missing the current text model configuration.

This adds the model to `benchmark/deepplanning/models_config.json` using the existing OpenAI-compatible configuration shape and API key environment variable.

Checks:
- `python3 -m json.tool benchmark/deepplanning/models_config.json`
- Loaded the new configuration through both DeepPlanning `load_model_config` implementations and verified its model ID and base URL.
- `git diff --check HEAD^`
