### PR TITLE
fix: merge parallel tool call chunks by index

### DIFF
--- a/qwen_agent/llm/oai.py
+++ b/qwen_agent/llm/oai.py
@@ -120,7 +120,7 @@ class TextChatAtOAI(BaseFnCallModel):
             else:
                 full_response = ''
                 full_reasoning_content = ''
-                full_tool_calls = []
+                full_tool_calls: Dict[int, Message] = {}
                 for chunk in response:
                     if chunk.choices:
                         if hasattr(chunk.choices[0].delta,
@@ -130,19 +130,25 @@ class TextChatAtOAI(BaseFnCallModel):
                             full_response += chunk.choices[0].delta.content
                         if hasattr(chunk.choices[0].delta, 'tool_calls') and chunk.choices[0].delta.tool_calls:
                             for tc in chunk.choices[0].delta.tool_calls:
-                                if full_tool_calls and (not tc.id or
-                                                        tc.id == full_tool_calls[-1]['extra']['function_id']):
-                                    if tc.function.name:
-                                        full_tool_calls[-1].function_call['name'] += tc.function.name
-                                    if tc.function.arguments:
-                                        full_tool_calls[-1].function_call['arguments'] += tc.function.arguments
-                                else:
-                                    full_tool_calls.append(
-                                        Message(role=ASSISTANT,
-                                                content='',
-                                                function_call=FunctionCall(name=tc.function.name,
-                                                                           arguments=tc.function.arguments),
-                                                extra={'function_id': tc.id}))
+                                if tc.function is None:
+                                    continue
+
+                                if tc.index not in full_tool_calls:
+                                    full_tool_calls[tc.index] = Message(role=ASSISTANT,
+                                                                        content='',
+                                                                        function_call=FunctionCall(
+                                                                            name=tc.function.name or '',
+                                                                            arguments=tc.function.arguments or ''),
+                                                                        extra={'function_id': tc.id})
+                                    continue
+
+                                tool_call = full_tool_calls[tc.index]
+                                if tc.id:
+                                    tool_call.extra['function_id'] = tc.id
+                                if tc.function.name:
+                                    tool_call.function_call['name'] += tc.function.name
+                                if tc.function.arguments:
+                                    tool_call.function_call['arguments'] += tc.function.arguments
 
                         res = []
                         if full_reasoning_content:
@@ -153,7 +159,7 @@ class TextChatAtOAI(BaseFnCallModel):
                                 content=full_response,
                             ))
                         if full_tool_calls:
-                            res += full_tool_calls
+                            res += [full_tool_calls[index] for index in sorted(full_tool_calls)]
                         yield res
         except OpenAIError as ex:
             raise ModelServiceError(exception=ex)

--- a/tests/llm/test_oai.py
+++ b/tests/llm/test_oai.py
@@ -1,11 +1,11 @@
 # Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -65,3 +66,40 @@ def test_llm_oai(functions, stream, delta_stream):
         assert response[-1].function_call.name == 'image_gen'
     else:
         assert response[-1].function_call is None
+
+
+def test_parallel_tool_call_chunks_are_merged_by_index():
+
+    def tool_call(index, call_id=None, name=None, arguments=None):
+        return SimpleNamespace(index=index, id=call_id, function=SimpleNamespace(name=name, arguments=arguments))
+
+    def chunk(*tool_calls):
+        delta = SimpleNamespace(content=None, reasoning_content=None, tool_calls=list(tool_calls))
+        return SimpleNamespace(choices=[SimpleNamespace(delta=delta)])
+
+    chunks = [
+        chunk(
+            tool_call(0, call_id='call-weather', name='get_weather', arguments='{"city":"'),
+            tool_call(1, call_id='call-time', name='get_time', arguments='{"zone":"'),
+        ),
+        chunk(
+            tool_call(0, arguments='Paris"}'),
+            tool_call(1, arguments='UTC"}'),
+        ),
+    ]
+    llm = get_chat_model({'model': 'test', 'model_server': 'http://localhost/v1', 'api_key': 'EMPTY'})
+    llm._chat_complete_create = lambda **kwargs: iter(chunks)
+
+    responses = list(
+        llm._chat_stream(
+            messages=[Message(role='user', content='Run both tools')],
+            delta_stream=False,
+            generate_cfg={},
+        ))
+
+    tool_calls = [message for message in responses[-1] if message.function_call]
+    assert [(message.function_call.name, message.function_call.arguments) for message in tool_calls] == [
+        ('get_weather', '{"city":"Paris"}'),
+        ('get_time', '{"zone":"UTC"}'),
+    ]
+    assert [message.extra['function_id'] for message in tool_calls] == ['call-weather', 'call-time']


### PR DESCRIPTION
## Summary

Fix non-delta streaming responses when multiple tool calls are emitted in parallel.

OpenAI-compatible streams identify each tool-call fragment with `ChoiceDeltaToolCall.index`, while `id` is commonly present only on the first fragment. The previous aggregator treated an absent `id` as a continuation of the most recently seen call. With interleaved fragments, arguments from earlier calls were therefore appended to the final call, leaving one call incomplete and another with invalid concatenated JSON.

This change:

- aggregates fragments by their protocol `index`;
- preserves tool-call order when emitting messages;
- accepts nullable name and argument fragments;
- updates a call ID if a provider sends it in a later fragment.

## Regression coverage

The new offline test streams two interleaved tool calls. Before this change, the first call remained incomplete and the second contained fragments from both calls. It now verifies both function names, complete JSON arguments, order, and call IDs.

## Validation

- `pytest -q tests/llm/test_oai.py -k parallel_tool_call_chunks_are_merged_by_index`
  - passed with `openai==0.28.1`
  - passed with `openai==3.3.1`
- `pre-commit run --files qwen_agent/llm/oai.py tests/llm/test_oai.py`
- `python -m compileall -q qwen_agent`
- `python setup.py sdist bdist_wheel`
