### PR TITLE
fix(security): path traversal in get_basename_from_url allows arbitrary file write

### DIFF
--- a/qwen_agent/utils/utils.py
+++ b/qwen_agent/utils/utils.py
@@ -116,13 +116,16 @@ def get_basename_from_url(path_or_url: str) -> str:
     # "https://github.com/here?k=v" -> "here"
     # "https://github.com/" -> ""
     basename = urllib.parse.urlparse(path_or_url).path
-    basename = os.path.basename(basename)
+    # SECURITY: decode percent-escapes BEFORE isolating the leaf name, so that
+    # "..%2f" cannot turn into "../" after sanitization (CVE-style traversal).
     basename = urllib.parse.unquote(basename)
+    basename = os.path.basename(os.path.normpath(basename))
     basename = basename.strip()
 
     # "https://github.com/" -> "" -> "github.com"
-    if not basename:
-        basename = [x.strip() for x in path_or_url.split('/') if x.strip()][-1]
+    if not basename or basename in ('.', '..'):
+        fallback = [x.strip() for x in path_or_url.split('/') if x.strip()]
+        basename = os.path.basename(urllib.parse.unquote(fallback[-1])) if fallback else 'file'
 
     return basename
 
@@ -181,10 +184,20 @@ def sanitize_windows_file_path(file_path: str) -> str:
     return file_path
 
 
+def _ensure_within_directory(path: str, directory: str) -> None:
+    """Raise ValueError if path escapes directory after symlink/.. resolution."""
+    real_dir = os.path.realpath(directory)
+    real_path = os.path.realpath(path)
+    if os.path.commonpath([real_path, real_dir]) != real_dir:
+        raise ValueError(f'Refusing unsafe path {path!r} outside of {directory!r}')
+
+
 def save_url_to_local_work_dir(url: str, save_dir: str, save_filename: str = '') -> str:
     if not save_filename:
         save_filename = get_basename_from_url(url)
     new_path = os.path.join(save_dir, save_filename)
+    # SECURITY: containment check — basename must not traverse out of save_dir
+    _ensure_within_directory(new_path, save_dir)
     if os.path.exists(new_path):
         os.remove(new_path)
     logger.info(f'Downloading {url} to {new_path}...')

--- a/qwen_server/database_server.py
+++ b/qwen_server/database_server.py
@@ -96,6 +96,11 @@ def cache_page(**kwargs):
         # map to local url
         os.makedirs(os.path.join(server_config.path.download_root, hash_sha256(url)), exist_ok=True)
         url = os.path.join(server_config.path.download_root, hash_sha256(url), get_basename_from_url(url))
+        # SECURITY: containment check — the derived path must stay in download_root
+        if os.path.commonpath([os.path.realpath(url),
+                               os.path.realpath(server_config.path.download_root)
+                               ]) != os.path.realpath(server_config.path.download_root):
+            raise ValueError(f'Refusing unsafe path {url!r} outside of download_root')
         save_browsing_meta_data(url, '[CACHING]', meta_file)
         # rm history
         save_history(None, url, history_dir)

--- a/tests/qwen_server/test_database_server.py
+++ b/tests/qwen_server/test_database_server.py
@@ -58,3 +58,34 @@ def test_database_server():
     update_pop_url(new_url)
     cache_file_popup_url = os.path.join(server_config.path.work_space_root, 'popup_url.jsonl')
     assert os.path.exists(cache_file_popup_url)
+
+
+def test_cache_page_traversal_url_stays_in_download_root():
+    # Regression: encoded '..%2f' must not escape download_root when the
+    # basename is decoded after sanitization (see get_basename_from_url).
+    server_config_path = Path(__file__).resolve().parent.parent.parent / 'qwen_server/server_config.json'
+    with open(server_config_path, 'r') as f:
+        server_config = GlobalConfig(**json.load(f))
+    if os.path.exists('workspace'):
+        shutil.rmtree('workspace')
+    os.makedirs(server_config.path.work_space_root)
+    os.makedirs(server_config.path.download_root)
+    os.makedirs(server_config.path.code_interpreter_ws)
+
+    from qwen_server.database_server import cache_page
+
+    data = {
+        'url':
+            'https://github.com/a/..%2f..%2f..%2fpwned.html',
+        'content':
+            '<p>pwned</p>'
+    }
+    try:
+        cache_page(**data)
+    except ValueError:
+        return  # containment check refused the write
+
+    resolved = os.path.realpath(os.path.join(server_config.path.download_root, hash_sha256(data['url']),
+                                             get_basename_from_url(data['url'])))
+    allowed = os.path.realpath(server_config.path.download_root)
+    assert os.path.commonpath([resolved, allowed]) == allowed


### PR DESCRIPTION
## Summary

`get_basename_from_url()` percent-decodes the URL path **after** calling `os.path.basename()`. Encoded traversal sequences (`..%2f`, `%2e%2e%2f`) therefore pass sanitization as literal text and re-expand into `../` in the returned value. Callers join this value into local filesystem paths and write attacker-controlled content.

## Impact

**Arbitrary file write with attacker-controlled content**, via two paths:

1. **Unauthenticated remote** — `qwen_server/database_server.py` exposes `POST /endpoint` without auth (and `run_server.py -s 0.0.0.0` is a documented mode). Task `cache` (`cache_page`) derives the write path from the caller-supplied `url`:
```bash
curl -X POST http://HOST:PORT/endpoint -H 'Content-Type: application/json' -d '{
  "task": "cache",
  "url": "http://attacker.example/a/..%2f..%2f..%2fhome%2fvictim%2f.ssh%2fauthorized_keys.html",
  "content": "ssh-ed25519 AAAA..."
}'
```
2. **Agent-side** — `save_url_to_local_work_dir()` uses the same function for every URL an agent ingests; a prompt-injected fetch achieves arbitrary write on the end user's machine.

Note: the traversal arrives inside an ordinary http(s) URL, so it also survives the `validate_url()` check proposed in #931.

## Root cause

```python
basename = os.path.basename(basename)      # strips "/" — but %2F is not "/"
basename = urllib.parse.unquote(basename)  # NOW %2F -> "/", "../" appears
```

## Fix

- decode percent-escapes **before** leaf-name isolation; normalize; reject dot-segment leaves
- defense in depth: realpath containment checks at both write sites (`save_url_to_local_work_dir`, `cache_page`)

## Verification

Regression test added to the existing `tests/qwen_server/test_database_server.py`:

| source under test | result |
|---|---|
| vulnerable `main` | **FAILS** — asserts the resolved write path escaped `download_root` |
| this branch | **PASSES** — containment check refuses the write |

A self-contained PoC is available on request (writes only under `/tmp`).

## Severity

~CVSS 9.8 (AV:N/AC:L/PR:N/UI:N) when the database server is network-exposed; ~8.1 via agent ingestion.