### PR TITLE
fix(examples): fix loop variable overwrite in function_calling_in_parallel

### DIFF
--- a/examples/function_calling_in_parallel.py
+++ b/examples/function_calling_in_parallel.py
@@ -76,7 +76,7 @@ def test():
 
     print('# Assistant Response 1:')
     responses = []
-    for responses in llm.chat(
+    for response in llm.chat(
             messages=messages,
             functions=functions,
             stream=True,
@@ -92,7 +92,8 @@ def test():
                 # function_choice='get_current_weather',
             ),
     ):
-        print(responses)
+        print(response)
+        responses = response
 
     messages.extend(responses)  # extend conversation with assistant's reply
 
@@ -125,7 +126,7 @@ def test():
             })  # extend conversation with function response
 
         print('# Assistant Response 2:')
-        for responses in llm.chat(
+        for response in llm.chat(
                 messages=messages,
                 functions=functions,
                 extra_generate_cfg={
@@ -134,7 +135,7 @@ def test():
                 },
                 stream=True,
         ):  # get a new response from the model where it can see the function response
-            print(responses)
+            print(response)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #661

### Summary
In `examples/function_calling_in_parallel.py`, `responses` was used both as the loop variable iterating over the stream generator in `for responses in llm.chat(...)` and as the variable holding the final list of messages.

When using streaming mode where chunks or intermediate messages are yielded, shadowing/overwriting `responses` in the loop variable caused issues when referencing `responses` in Step 2 (`[rsp for rsp in responses if rsp.get('function_call', None)]`).

This PR updates the iteration variable to `response` and properly sets `responses = response` across stream updates, consistent with standard generator iteration patterns.