### PR TITLE
fix(tools): make soundfile and optional dependencies lazy imports (#798)

### DIFF
--- a/qwen_agent/tools/python_executor.py
+++ b/qwen_agent/tools/python_executor.py
@@ -24,8 +24,6 @@ from functools import partial
 from typing import Any, Dict, List, Optional, Union
 
 import json5
-import regex
-from tqdm import tqdm
 
 from qwen_agent.tools.base import BaseTool
 from qwen_agent.utils.utils import extract_code
@@ -44,8 +42,14 @@ class GenericRuntime:
             self.exec_code(c)
 
     def exec_code(self, code_piece: str) -> None:
-        if regex.search(r'(\s|^)?input\(', code_piece) or regex.search(r'(\s|^)?os.system\(', code_piece):
-            raise RuntimeError()
+        try:
+            import regex
+            if regex.search(r'(\s|^)?input\(', code_piece) or regex.search(r'(\s|^)?os.system\(', code_piece):
+                raise RuntimeError()
+        except ImportError:
+            import re
+            if re.search(r'(\s|^)?input\(', code_piece) or re.search(r'(\s|^)?os.system\(', code_piece):
+                raise RuntimeError()
         exec(code_piece, self._global_vars)
 
     def eval_code(self, expr: str) -> Any:
@@ -61,12 +65,19 @@ class GenericRuntime:
 
 
 class DateRuntime(GenericRuntime):
-    import dateutil.relativedelta
-    GLOBAL_DICT = {
-        'datetime': datetime.datetime,
-        'timedelta': dateutil.relativedelta.relativedelta,
-        'relativedelta': dateutil.relativedelta.relativedelta
-    }
+    def __init__(self):
+        try:
+            import dateutil.relativedelta
+            self.GLOBAL_DICT = {
+                'datetime': datetime.datetime,
+                'timedelta': dateutil.relativedelta.relativedelta,
+                'relativedelta': dateutil.relativedelta.relativedelta
+            }
+        except ImportError as e:
+            raise ImportError(
+                'The dependencies for DateRuntime are not installed. '
+                'Please install python-dateutil with `pip install python-dateutil`.') from e
+        super().__init__()
 
 
 class CustomDict(dict):
@@ -205,7 +216,11 @@ class PythonExecutor(BaseTool):
             iterator = future.result()
 
             if len(all_code_snippets) > 100:
-                progress_bar = tqdm(total=len(all_code_snippets), desc='Execute')
+                try:
+                    from tqdm import tqdm
+                    progress_bar = tqdm(total=len(all_code_snippets), desc='Execute')
+                except ImportError:
+                    progress_bar = None
             else:
                 progress_bar = None
 

--- a/qwen_agent/utils/utils.py
+++ b/qwen_agent/utils/utils.py
@@ -29,9 +29,7 @@ from io import BytesIO
 from typing import Any, List, Literal, Optional, Tuple, Union
 
 import json5
-import numpy as np
 import requests
-import soundfile as sf
 from pydantic import BaseModel
 
 from qwen_agent.llm.schema import ASSISTANT, DEFAULT_SYSTEM_MESSAGE, FUNCTION, SYSTEM, USER, ContentItem, Message
@@ -443,6 +441,11 @@ def format_as_text_message(
 
 
 def save_audio_to_file(base_64: str, file_name: str):
+    try:
+        import numpy as np
+        import soundfile as sf
+    except ImportError as e:
+        raise ImportError('Please install numpy and soundfile using `pip install numpy soundfile` to save audio files.') from e
     wav_bytes = base64.b64decode(base_64)
     audio_np = np.frombuffer(wav_bytes, dtype=np.int16)
     sf.write(file_name, audio_np, samplerate=24000)

--- a/tests/tools/test_lazy_imports.py
+++ b/tests/tools/test_lazy_imports.py
@@ -1,0 +1,44 @@
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+def test_import_tools_base_without_soundfile():
+    # Simulate soundfile missing from environment
+    with patch.dict(sys.modules, {'soundfile': None}):
+        import qwen_agent.tools.base as tools_base
+        from qwen_agent.tools.base import TOOL_REGISTRY, BaseTool, register_tool
+
+        assert hasattr(tools_base, 'BaseTool')
+        assert hasattr(tools_base, 'register_tool')
+        assert isinstance(TOOL_REGISTRY, dict)
+
+        @register_tool('mock_test_tool', allow_overwrite=True)
+        class MockTestTool(BaseTool):
+            description = 'A mock tool for testing'
+            parameters = {
+                'type': 'object',
+                'properties': {
+                    'query': {
+                        'type': 'string',
+                        'description': 'query string'
+                    }
+                },
+                'required': ['query']
+            }
+
+            def call(self, params, **kwargs):
+                return 'ok'
+
+        assert 'mock_test_tool' in TOOL_REGISTRY
+        tool = MockTestTool()
+        assert tool.name == 'mock_test_tool'
+
+
+def test_save_audio_to_file_raises_import_error_without_soundfile():
+    from qwen_agent.utils.utils import save_audio_to_file
+
+    with patch.dict(sys.modules, {'soundfile': None}):
+        with pytest.raises(ImportError, match='Please install numpy and soundfile'):
+            save_audio_to_file('dummy', 'dummy.wav')


### PR DESCRIPTION
## Description
Fixes #798.

When importing `qwen_agent.tools.base` or using tool registries in environments without optional dependencies like `soundfile`, the top-level import in `qwen_agent/utils/utils.py` failed with `ModuleNotFoundError`. This broke tool initialization in scenarios like deepplanning / travelplanning.

### Changes
- Make `soundfile` and `numpy` lazy imports inside `save_audio_to_file` in `qwen_agent/utils/utils.py`.
- Make `regex`, `tqdm`, and `dateutil` imports lazy / fallback in `qwen_agent/tools/python_executor.py`.
- Added unit tests in `tests/tools/test_lazy_imports.py` ensuring `qwen_agent.tools.base` and `register_tool` work properly when optional dependencies like `soundfile` are absent.