### PR TITLE
fix(web-search): add a request timeout

### DIFF
--- a/qwen_agent/tools/web_search.py
+++ b/qwen_agent/tools/web_search.py
@@ -21,6 +21,7 @@ from qwen_agent.tools.base import BaseTool, register_tool
 
 SERPER_API_KEY = os.getenv('SERPER_API_KEY', '')
 SERPER_URL = os.getenv('SERPER_URL', 'https://google.serper.dev/search')
+SERPER_TIMEOUT = 30
 
 
 @register_tool('web_search', allow_overwrite=True)
@@ -53,7 +54,7 @@ class WebSearch(BaseTool):
             )
         headers = {'Content-Type': 'application/json', 'X-API-KEY': SERPER_API_KEY}
         payload = {'q': query}
-        response = requests.post(SERPER_URL, json=payload, headers=headers)
+        response = requests.post(SERPER_URL, json=payload, headers=headers, timeout=SERPER_TIMEOUT)
         response.raise_for_status()
 
         return response.json()['organic']

--- a/tests/tools/test_web_search.py
+++ b/tests/tools/test_web_search.py
@@ -1,0 +1,32 @@
+# Copyright 2023 The Qwen team, Alibaba Group. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+from qwen_agent.tools import web_search
+
+
+def test_web_search_request_has_timeout():
+    with patch.object(web_search, 'SERPER_API_KEY', 'test-key'):
+        with patch.object(web_search.requests, 'post') as post:
+            post.return_value.json.return_value = {'organic': []}
+
+            assert web_search.WebSearch.search('agent') == []
+
+            post.assert_called_once_with(
+                web_search.SERPER_URL,
+                json={'q': 'agent'},
+                headers={'Content-Type': 'application/json', 'X-API-KEY': 'test-key'},
+                timeout=web_search.SERPER_TIMEOUT,
+            )


### PR DESCRIPTION
## Summary

- add a bounded timeout to Serper web-search requests
- prevent an unresponsive endpoint from blocking an agent tool call indefinitely
- cover the request contract with a focused mocked test

## Validation

- focused before/after mocked request reproduction
- `python3 -m compileall -q qwen_agent/tools/web_search.py tests/tools/test_web_search.py`
- `git diff --cached --check`
