### PR TITLE
fix: stop Router from function-calling when function_list is set

### DIFF
--- a/qwen_agent/agents/router.py
+++ b/qwen_agent/agents/router.py
@@ -65,11 +65,19 @@ class Router(Assistant, MultiAgentHub):
             if msg[ROLE] == ASSISTANT:
                 msg = self.supplement_name_special_token(msg)
             messages_for_router.append(msg)
+        messages_for_router = self._prepend_knowledge_prompt(messages=messages_for_router, lang=lang, **kwargs)
+
+        extra_generate_cfg = {'lang': lang}
+        if kwargs.get('seed') is not None:
+            extra_generate_cfg['seed'] = kwargs['seed']
+        # Routing uses Call:/Reply: text, not native function-calling (issue #622).
         response = []
-        for response in super()._run(messages=messages_for_router, lang=lang, **kwargs):
+        for response in self._call_llm(messages=messages_for_router,
+                                       functions=None,
+                                       extra_generate_cfg=extra_generate_cfg):
             yield response
 
-        if 'Call:' in response[-1].content and self.agents:
+        if response and 'Call:' in response[-1].content and self.agents:
             # According to the rule in prompt to selected agent
             selected_agent_name = response[-1].content.split('Call:')[-1].strip().split('\n')[0].strip()
             logger.info(f'Need help from {selected_agent_name}')

--- a/tests/agents/test_router.py
+++ b/tests/agents/test_router.py
@@ -13,7 +13,34 @@
 # limitations under the License.
 
 from qwen_agent.agents import Assistant, Router
-from qwen_agent.llm.schema import ContentItem, Message
+from qwen_agent.llm.schema import ContentItem, FunctionCall, Message
+from qwen_agent.tools.base import BaseTool
+
+
+class DummyTool(BaseTool):
+    name = 'dummy_tool'
+    description = 'A dummy tool for tests.'
+
+    def call(self, params, **kwargs):
+        return 'dummy-result'
+
+
+class FakeLLM:
+    """Minimal LLM stub that records chat() calls and returns scripted replies."""
+
+    def __init__(self, replies):
+        self.model = 'fake-llm'
+        self.model_type = 'fake'
+        self.calls = []
+        self._replies = list(replies)
+
+    def chat(self, messages, functions=None, stream=True, extra_generate_cfg=None, **kwargs):
+        self.calls.append({'functions': functions})
+        reply = self._replies.pop(0)
+        if stream:
+            yield reply
+        else:
+            return reply
 
 
 def test_router():
@@ -51,3 +78,83 @@ def test_router():
     assert last[-3].function_call.arguments == '{"location": "海淀区"}'
     assert last[-2].name == 'amap_weather'
     assert len(last[-1].content) > 0
+
+
+def test_router_direct_reply_with_function_list():
+    router_llm = FakeLLM([[Message(role='assistant', content='Hello!')]])
+    child_llm = FakeLLM([[Message(role='assistant', content='child should not be called')]])
+    child = Assistant(llm=child_llm, name='weather_agent', description='query weather')
+    bot = Router(llm=router_llm, agents=[child], function_list=[DummyTool()])
+
+    *_, last = bot.run([Message('user', 'hi')])
+
+    assert not router_llm.calls[0]['functions']
+    assert not child_llm.calls
+    assert last[-1].content == 'Hello!'
+    assert all(msg.role != 'function' for msg in last)
+
+
+def test_router_function_list_does_not_pass_tools_on_routing_turn():
+    router_llm = FakeLLM([[Message(role='assistant', content='Call: weather_agent')]])
+    child_llm = FakeLLM([[Message(role='assistant', content='Sunny in Beijing')]])
+    child = Assistant(llm=child_llm,
+                      name='weather_agent',
+                      description='query weather',
+                      function_list=[DummyTool()])
+    bot = Router(llm=router_llm, agents=[child], function_list=[DummyTool()])
+
+    *_, last = bot.run([Message('user', 'what is the weather in Beijing?')])
+
+    assert router_llm.calls, 'Router should call the LLM once for routing'
+    assert not router_llm.calls[0]['functions']
+    assert last[-1].content == 'Sunny in Beijing'
+    assert last[-1].name == 'weather_agent'
+    assert all('does not exists' not in (msg.content or '') for msg in last)
+
+
+def test_router_function_list_does_not_execute_hallucinated_tools():
+    router_llm = FakeLLM([[
+        Message(role='assistant',
+                content='',
+                function_call=FunctionCall(name='invented_tool', arguments='{}'),
+                extra={})
+    ]])
+    child_llm = FakeLLM([[Message(role='assistant', content='child should not be called')]])
+    child = Assistant(llm=child_llm,
+                      name='weather_agent',
+                      description='query weather',
+                      function_list=[DummyTool()])
+    bot = Router(llm=router_llm, agents=[child], function_list=[DummyTool()])
+
+    *_, last = bot.run([Message('user', 'what is the weather in Beijing?')])
+
+    assert not router_llm.calls[0]['functions']
+    assert not child_llm.calls
+    assert all(msg.role != 'function' for msg in last)
+    assert all('does not exists' not in (msg.content or '') for msg in last)
+
+
+def test_router_still_lets_child_agent_use_tools():
+    router_llm = FakeLLM([[Message(role='assistant', content='Call: weather_agent')]])
+    child_llm = FakeLLM([
+        [
+            Message(role='assistant',
+                    content='',
+                    function_call=FunctionCall(name='dummy_tool', arguments='{}'),
+                    extra={})
+        ],
+        [Message(role='assistant', content='Sunny in Beijing')],
+    ])
+    child = Assistant(llm=child_llm,
+                      name='weather_agent',
+                      description='query weather',
+                      function_list=[DummyTool()])
+    bot = Router(llm=router_llm, agents=[child], function_list=[DummyTool()])
+
+    *_, last = bot.run([Message('user', 'what is the weather in Beijing?')])
+
+    assert not router_llm.calls[0]['functions']
+    assert child_llm.calls[0]['functions']
+    assert any(msg.role == 'function' and msg.name == 'dummy_tool' for msg in last)
+    assert last[-1].content == 'Sunny in Beijing'
+    assert last[-1].name == 'weather_agent'


### PR DESCRIPTION
## Summary
- Router multi-agent routing no longer enters function-calling mode when `function_list` is passed to the Router constructor.
- Root cause: `Router` inherits `Assistant`/`FnCallAgent`. Passing `function_list` made the routing turn hand tools to the LLM, so it could invent tools instead of following the `Call:` / `Reply:` protocol and then fail with `Tool ... does not exists.`
- Fix: the routing LLM call uses `functions=None`; keep tools on child agents only.

## Test plan
- [x] Mock-LLM unit tests: router with `function_list` does not emit tool calls; child agents still receive tools; `Call:` routing still works

Fixes #622