### PR TITLE
fix(mcp): support MCP SDK 2.x streamable-http client while keeping 1.x

### DIFF
--- a/qwen_agent/tools/mcp_manager.py
+++ b/qwen_agent/tools/mcp_manager.py
@@ -326,7 +326,15 @@ class MCPClient:
         from mcp import ClientSession, StdioServerParameters
         from mcp.client.sse import sse_client
         from mcp.client.stdio import stdio_client
-        from mcp.client.streamable_http import streamablehttp_client
+        try:  # mcp 1.x; this name was removed in mcp 2.0
+            from mcp.client.streamable_http import streamablehttp_client
+
+            streamable_http_uses_mcp_v2 = False
+        except ImportError:  # mcp >= 2.0 renamed the client and changed its signature
+            from mcp.client.streamable_http import streamable_http_client
+            from mcp.shared._httpx_utils import create_mcp_http_client
+
+            streamable_http_uses_mcp_v2 = True
         """Connect to an MCP server and retrieve the available tools."""
         # Save parameters
         self._last_mcp_server_name = mcp_server_name
@@ -349,10 +357,26 @@ class MCPClient:
                     }
                     """
                     headers = mcp_server.get('headers', {})
-                    self._streams_context = streamablehttp_client(
-                        url=url, headers=headers, sse_read_timeout=datetime.timedelta(seconds=sse_read_timeout))
-                    read_stream, write_stream, get_session_id = await self.exit_stack.enter_async_context(
-                        self._streams_context)
+                    if streamable_http_uses_mcp_v2:
+                        # mcp >= 2.0 takes a pre-configured httpx2 client and
+                        # yields a 2-tuple. Build the client ourselves so the
+                        # headers and SSE read timeout still apply, and enter
+                        # it into the stack before the transport so it is
+                        # closed last (the transport only closes clients it
+                        # created itself).
+                        import httpx2
+                        http_client = create_mcp_http_client(
+                            headers=headers or None,
+                            timeout=httpx2.Timeout(30.0, read=sse_read_timeout))
+                        await self.exit_stack.enter_async_context(http_client)
+                        self._streams_context = streamable_http_client(url=url, http_client=http_client)
+                        read_stream, write_stream = await self.exit_stack.enter_async_context(
+                            self._streams_context)
+                    else:
+                        self._streams_context = streamablehttp_client(
+                            url=url, headers=headers, sse_read_timeout=datetime.timedelta(seconds=sse_read_timeout))
+                        read_stream, write_stream, get_session_id = await self.exit_stack.enter_async_context(
+                            self._streams_context)
                     self._session_context = ClientSession(read_stream, write_stream)
                     self.session = await self.exit_stack.enter_async_context(self._session_context)
                 else:


### PR DESCRIPTION
Fixes #949.

## What

`connection_server()` in `qwen_agent/tools/mcp_manager.py` imported `streamablehttp_client` from `mcp.client.streamable_http`, which no longer exists in MCP SDK 2.0.0 — configuring an MCP server with `"type": "streamable-http"` raised `ImportError` (or `NameError` on older versions) whenever `mcp>=2.0.0` was installed.

This PR makes the streamable-http path work on both SDK generations:

- mcp 1.x (all 1.x releases, including 1.29 where a forward-compat alias exists): unchanged code path — the original `streamablehttp_client(url, headers=..., sse_read_timeout=...)` call and its 3-tuple unpacking.
- mcp >= 2.0: the renamed `streamable_http_client(url, http_client=...)` with the new 2-tuple result. Headers and `sse_read_timeout` are preserved by building the HTTP client through mcp's own `create_mcp_http_client(headers=..., timeout=httpx2.Timeout(30.0, read=sse_read_timeout))`. The client is entered into the exit stack before the transport so it closes last (the 2.x transport only closes clients it created itself).

The SDK generation is detected by attempting the 1.x import first and falling back: `streamablehttp_client` exists in every 1.x release and is removed in 2.0. Note that late 1.x versions (e.g. 1.29) also expose a `streamable_http_client` alias, so detecting the new name alone would misroute those installs — the old name is what cleanly separates the two.

## How tested

- E2E against a real MCP server over streamable-http (server run in-process from the installed SDK), with `mcp==2.0.0`: patched client connects, session initializes, and `list_tools()` returns the served tool; asserts pass (`TOOLS: ['echo']`). On unpatched code with the same SDK the run fails with `ImportError: cannot import name 'streamablehttp_client'`, reproducing #949.
- Same E2E with `mcp==1.29.1`: the unchanged 1.x path still connects and lists tools, confirming no regression for current installs (the fallback branch was exercised, verified by the two runs taking different branches).
